### PR TITLE
Add approx_eq() functions and unit test doc

### DIFF
--- a/include/mat.hpp
+++ b/include/mat.hpp
@@ -362,12 +362,12 @@ public:
 
     // Check equality of two MxM matrices
     friend constexpr bool operator==(const MatT& lhs, const MatT& rhs) {
-        return lhs.rows_ == rhs.rows_;
+        return approx_eq(lhs, rhs);
     }
 
     // Check inequality of two MxM matrices
     friend constexpr bool operator!=(const MatT& lhs, const MatT& rhs) {
-        return lhs.rows_ != rhs.rows_;
+        return !approx_eq(lhs, rhs);
     }
 
     // Add two MxM matrices
@@ -444,6 +444,22 @@ public:
         std::copy(rhs.rows_.cbegin(), rhs.rows_.cend(), joiner);
         os << "]";
         return os;
+    }
+
+    /**************************************************************************
+     * FRIEND FUNCTIONS
+     **************************************************************************/
+
+    // Check if two MxM matrices are approximately equal
+    friend constexpr bool approx_eq(MatT a, MatT b,
+                                    Type epsilon = utils::kFloatEqDefaultEpsilon<Type>,
+                                    Type abs_threshold = utils::kFloatEqDefaultAbsThreshold<Type>) {
+        auto row_compare = [epsilon, abs_threshold](const VecT& a_row, const VecT& b_row) {
+            return approx_eq(a_row, b_row, epsilon, abs_threshold);
+        };
+        return std::equal(a.cbegin(), a.cend(), // a input
+                          b.cbegin(),           // b input
+                          row_compare);         // comparison
     }
 
 private:

--- a/include/vec.hpp
+++ b/include/vec.hpp
@@ -284,19 +284,14 @@ public:
         return out;
     }
 
-    // Check equality of two M-dimensional vectors
+    // Check approximate equality of two M-dimensional vectors
     friend constexpr bool operator==(const VecT& lhs, const VecT& rhs) {
-        auto float_compare = [](const Type& lhs_elem, const Type& rhs_elem) {
-            return utils::floating_point_eq(lhs_elem, rhs_elem);
-        };
-        return std::equal(lhs.cbegin(), lhs.cend(), // lhs input
-                          rhs.cbegin(),             // rhs input
-                          float_compare);           // comparison
+        return approx_eq(lhs, rhs);
     }
 
-    // Check inequality of two M-dimensional vectors
+    // Check approximate inequality of two M-dimensional vectors
     friend constexpr bool operator!=(const VecT& lhs, const VecT& rhs) {
-        return !(lhs == rhs); // leverage operator== implementation
+        return !approx_eq(lhs, rhs);
     }
 
     // Add two M-dimensional vectors
@@ -356,6 +351,18 @@ public:
     /**************************************************************************
      * FRIEND FUNCTIONS
      **************************************************************************/
+
+    // Check if two M-dimensional vectors are approximately equal
+    friend constexpr bool approx_eq(VecT a, VecT b,
+                                    Type epsilon = utils::kFloatEqDefaultEpsilon<Type>,
+                                    Type abs_threshold = utils::kFloatEqDefaultAbsThreshold<Type>) {
+        auto float_compare = [epsilon, abs_threshold](const Type& a_elem, const Type& b_elem) {
+            return utils::floating_point_eq<Type>(a_elem, b_elem, epsilon, abs_threshold);
+        };
+        return std::equal(a.cbegin(), a.cend(), // a input
+                          b.cbegin(),           // b input
+                          float_compare);       // comparison
+    }
 
     // Get the dot product of M-dimensional vectors a and b
     // TODO: make this a method instead; v1.dot(v2) is nice

--- a/tests/test_guidelines.md
+++ b/tests/test_guidelines.md
@@ -1,0 +1,42 @@
+# Unit Tests
+
+## Testing Guidelines
+* Test one function per test case
+* Template all test cases on `VALID_TYPES`
+* Name the test case according to what's being exercised
+* Within the test case, define `constexpr TestArray` values for test inputs and expected outputs
+    * Generally provide 4D inputs, unless the function under test doesn't exist for 4D vectors
+    * Specify literals as `long double` by appending `L` as a literal suffix.
+* Where appropriate, define `SUBCASE()` sections for 2D, 3D, and 4D vectors
+    * Perform all test operations and assertions within a `SUBCASE()`
+    * Utilize `getVec<Type, M>()` helper to get appropriately-sized vectors from `TestArray` values
+* Exercise all operations in fully `constexpr` manner wherever possible
+    * If the compile-time implementation of the function under test differs from the run-time 
+      implementation (i.e. the function uses `std::is_constant_evaluated()`), test the function 
+      in both a `constexpr` and non-`constexpr` context.
+      
+## Test Case Example
+```C++
+TEST_CASE_TEMPLATE("Vector-vector addition", Type, VALID_TYPES) {
+   constexpr TestArray kInput{1.0L, 2.0L, 3.0L, 4.0L};
+   constexpr TestArray kExpected{2.0L, 4.0L, 6.0L, 8.0L};
+   
+   SUBCASE("2D") {
+       constexpr auto v = getVec<Type, 2>(kInput);
+       constexpr auto out = v + v;
+       CHECK(out == getVec<Type, 2>(kExpected));
+   }
+   
+   SUBCASE("3D") {
+     constexpr auto v = getVec<Type, 3>(kInput);
+     constexpr auto out = v + v;
+     CHECK(out == getVec<Type, 3>(kExpected));
+   }
+
+   SUBCASE("4D") {
+       constexpr auto v = getVec<Type, 4>(kInput);
+       constexpr auto out = v + v;
+       CHECK(out == getVec<Type, 4>(kExpected));
+   }
+}
+```

--- a/tests/test_mat_basic.cpp
+++ b/tests/test_mat_basic.cpp
@@ -227,7 +227,7 @@ TEST_CASE_TEMPLATE("Access rows by index with at()", Type, VALID_TYPES) {
             CHECK(m.at(i) == getVec<Type, 2>({}));
         }
         // Out-of-bounds
-        CHECK_THROWS(m.at(2).normalize_in_place());
+        CHECK_THROWS(m.at(2).clear());
     }
 
     SUBCASE("3D") {
@@ -240,7 +240,7 @@ TEST_CASE_TEMPLATE("Access rows by index with at()", Type, VALID_TYPES) {
             CHECK(m.at(i) == getVec<Type, 3>({}));
         }
         // Out-of-bounds
-        CHECK_THROWS(m.at(3).normalize_in_place());
+        CHECK_THROWS(m.at(3).clear());
     }
 
     SUBCASE("4D") {
@@ -253,7 +253,7 @@ TEST_CASE_TEMPLATE("Access rows by index with at()", Type, VALID_TYPES) {
             CHECK(m.at(i) == getVec<Type, 4>({}));
         }
         // Out-of-bounds
-        CHECK_THROWS(m.at(4).normalize_in_place());
+        CHECK_THROWS(m.at(4).clear());
     }
 }
 

--- a/tests/test_mat_friends.cpp
+++ b/tests/test_mat_friends.cpp
@@ -1,4 +1,4 @@
-// Unit tests for the Vec class implementation
+// Unit tests for the Mat class implementation (friends)
 
 // Testing headers
 #define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
@@ -8,4 +8,32 @@
 // UUT headers
 #include "mat.hpp"
 
-// TODO
+TEST_CASE_TEMPLATE("Approximate equality", Type, VALID_TYPES) {
+    constexpr TestArray2D kInput1{{
+            {1.0L, 2.0L, 3.0L, 4.0L},
+            {5.0L, 6.0L, 7.0L, 8.0L},
+            {-1.0L, -2.0L, -3.0L, -4.0L},
+            {-5.0L, -6.0L, -7.0L, -8.0L},
+    }};
+    constexpr TestArray2D kInput2{{
+            {1.0001L, 2.0L, 3.0L, 4.0L}, // 0.0001 offset
+            {5.0L, 6.0L, 7.0L, 8.0L},
+            {-1.0L, -2.0L, -3.0L, -4.0L},
+            {-5.0L, -6.0L, -7.0L, -8.0L},
+    }};
+
+    SUBCASE("4D - Self") {
+        constexpr auto m1 = getMat<Type, 4>(kInput1);
+        constexpr bool self_eq = approx_eq(m1, m1);
+        CHECK(self_eq);
+    }
+
+    SUBCASE("4D - Epsilon") {
+        constexpr auto m1 = getMat<Type, 4>(kInput1);
+        constexpr auto m2 = getMat<Type, 4>(kInput2);
+        constexpr bool default_eps_eq = approx_eq(m1, m2);
+        constexpr bool custom_eps_eq = approx_eq(m1, m2, static_cast<Type>(0.001));
+        CHECK_FALSE(default_eps_eq);
+        CHECK(custom_eps_eq);
+    }
+}

--- a/tests/test_mat_operators.cpp
+++ b/tests/test_mat_operators.cpp
@@ -1,4 +1,4 @@
-// Unit tests for the Vec class implementation
+// Unit tests for the Mat class implementation (operators)
 
 // Testing headers
 #define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN

--- a/tests/test_utils/test_utils_vec.hpp
+++ b/tests/test_utils/test_utils_vec.hpp
@@ -29,6 +29,15 @@ constexpr Vec<Type, M> getVec(TestArray elems) {
     return v;
 }
 
+// Vec test guidelines:
+//  * Use TEST_CASE_TEMPLATE with VALID_TYPES
+//  * Define constexpr TestArray values for test inputs and output expectations
+//  * Where appropriate, define SUBCASE sections for 2D, 3D, and 4D vectors
+//      * Utilize getVec helper to get appropriately-sized vectors from TestArray values
+//      * If implementations are not specialized on size, default to testing 4D vectors
+//  * Exercise operations in a fully constexpr form wherever possible
+//      * If the constexpr and non-constexpr implementations differ, test both
+
 TEST_CASE("Basic checks to enable other tests") {
     SUBCASE("Element access with []") {
         // Helper getVec() above requires operator[] to set values

--- a/tests/test_vec_friends.cpp
+++ b/tests/test_vec_friends.cpp
@@ -8,6 +8,26 @@
 // UUT headers
 #include "vec.hpp"
 
+TEST_CASE_TEMPLATE("Approximate equality", Type, VALID_TYPES) {
+    constexpr TestArray kInput1{1.0L, 2.1L, -3.0L, 4.5L};
+    constexpr TestArray kInput2{1.0001L, 2.1L, -3.0L, 4.5L};
+
+    SUBCASE("4D - Self") {
+        constexpr auto v1 = getVec<Type, 4>(kInput1);
+        constexpr bool self_eq = approx_eq(v1, v1);
+        CHECK(self_eq);
+    }
+
+    SUBCASE("4D - Epsilon") {
+        constexpr auto v1 = getVec<Type, 4>(kInput1);
+        constexpr auto v2 = getVec<Type, 4>(kInput2);
+        constexpr bool default_eps_eq = approx_eq(v1, v2);
+        constexpr bool custom_eps_eq = approx_eq(v1, v2, static_cast<Type>(0.001));
+        CHECK_FALSE(default_eps_eq);
+        CHECK(custom_eps_eq);
+    }
+}
+
 TEST_CASE_TEMPLATE("Dot product", Type, VALID_TYPES) {
     // Shared input data:
     constexpr TestArray kInput1{1.0L, 2.1L, -3.0L, 4.5L};


### PR DESCRIPTION
Add approx_eq() function for both Vec and Mat to allow using a custom
epsilon and absolute threshold for floating point comparisons. Add unit
test coverage for each.

Also add a small unit test markdown document with testing guidelines and
an example test case.

resolves #1 