### PR TITLE
Add operator tests for matrix class and test util improvements

### DIFF
--- a/include/mat.hpp
+++ b/include/mat.hpp
@@ -60,8 +60,8 @@ public:
     // Construct matrix from individual elements (2x2 specialization)
     constexpr Mat(Type e00, Type e01,
                   Type e10, Type e11) requires Is2D<M>
-        : rows_{{e00, e01},
-                {e10, e11}} {}
+            : rows_{{e00, e01},
+                    {e10, e11}} {}
 
     // Construct matrix from individual elements (3x3 specialization)
     constexpr Mat(Type e00, Type e01, Type e02,
@@ -340,7 +340,7 @@ public:
 
     // Divide this MxM matrix by scalar
     constexpr MatT& operator/=(Type rhs) {
-        auto div_by_rhs = [rhs](auto& lhs_elem) { return lhs_elem * rhs; };
+        auto div_by_rhs = [rhs](auto& lhs_elem) { return lhs_elem / rhs; };
         std::transform(cbegin(), cend(), // this input
                        begin(),          // output
                        div_by_rhs);      // operation
@@ -395,9 +395,9 @@ public:
         MatT out;
         auto mult_by_rhs = [rhs](auto& lhs_elem) { return lhs_elem * rhs; };
         std::transform(lhs.cbegin(), lhs.cend(), // lhs input
-                       rhs.cbegin(),             // rhs input
                        out.begin(),              // output
                        mult_by_rhs);             // operation
+       return out;
     }
 
     // Multiply MxM matrix by scalar (reverse operand order)
@@ -410,7 +410,7 @@ public:
     // Get MxM product of two MxM matrices
     friend constexpr MatT operator*(const MatT& lhs, const MatT& rhs) {
         // TODO: Can we do this without raw loops?
-        // NOTE: SO suggests loop order matters here (for caching)
+        // NOTE: SO suggests alternate loop order here (for better caching)
         auto calc_element = [lhs, rhs](size_t i, size_t j) {
             Type sum = 0;
             for (int k = 0; k < M; k++) {
@@ -439,6 +439,7 @@ public:
 
     // Stream matrix contents in readable form (row by row)
     friend std::ostream& operator<<(std::ostream& os, const MatT& rhs) {
+        // TODO: Use iomanip to set print width for consistent column alignment
         auto joiner = std::experimental::make_ostream_joiner(os, "\n ");
         os << "\n[";
         std::copy(rhs.rows_.cbegin(), rhs.rows_.cend(), joiner);

--- a/tests/test_mat_basic.cpp
+++ b/tests/test_mat_basic.cpp
@@ -10,10 +10,10 @@
 
 TEST_CASE_TEMPLATE("Construct zero matrix", Type, VALID_TYPES) {
     constexpr TestGrid kExpected{{
-            {0.0L, 0.0L, 0.0L, 0.0L},
-            {0.0L, 0.0L, 0.0L, 0.0L},
-            {0.0L, 0.0L, 0.0L, 0.0L},
-            {0.0L, 0.0L, 0.0L, 0.0L},
+            {0.0, 0.0, 0.0, 0.0},
+            {0.0, 0.0, 0.0, 0.0},
+            {0.0, 0.0, 0.0, 0.0},
+            {0.0, 0.0, 0.0, 0.0},
     }};
 
     SUBCASE("2D") {
@@ -34,10 +34,10 @@ TEST_CASE_TEMPLATE("Construct zero matrix", Type, VALID_TYPES) {
 
 TEST_CASE_TEMPLATE("Construct matrix from column vectors", Type, VALID_TYPES) {
     constexpr TestGrid kTestValues{{
-            {1.0L, 2.0L, 3.0L, 4.0L},
-            {5.0L, 6.0L, 7.0L, 8.0L},
-            {-1.0L, -2.0L, -3.0L, -4.0L},
-            {-5.0L, -6.0L, -7.0L, -8.0L}
+            {1.0, 2.0, 3.0, 4.0},
+            {5.0, 6.0, 7.0, 8.0},
+            {-1.0, -2.0, -3.0, -4.0},
+            {-5.0, -6.0, -7.0, -8.0}
     }};
 
     SUBCASE("2D") {
@@ -71,10 +71,10 @@ TEST_CASE_TEMPLATE("Construct matrix from individual elements", Type, VALID_TYPE
 
 TEST_CASE_TEMPLATE("Construct matrix from other matrix", Type, VALID_TYPES) {
     constexpr TestGrid kTestValues{{
-            {1.0L, 2.0L, 3.0L, 4.0L},
-            {5.0L, 6.0L, 7.0L, 8.0L},
-            {-1.0L, -2.0L, -3.0L, -4.0L},
-            {-5.0L, -6.0L, -7.0L, -8.0L}
+            {1.0, 2.0, 3.0, 4.0},
+            {5.0, 6.0, 7.0, 8.0},
+            {-1.0, -2.0, -3.0, -4.0},
+            {-5.0, -6.0, -7.0, -8.0}
     }};
 
     SUBCASE("2D") {
@@ -98,12 +98,12 @@ TEST_CASE_TEMPLATE("Construct matrix from other matrix", Type, VALID_TYPES) {
 
 TEST_CASE_TEMPLATE("Construct matrix from single element fill", Type, VALID_TYPES) {
     // Shared input and expected output data:
-    constexpr Type kFillValue{static_cast<Type>(123.0L)};
+    constexpr Type kFillValue{static_cast<Type>(123.0)};
     constexpr TestGrid kExpected{{
-            {123.0L, 123.0L, 123.0L, 123.0L},
-            {123.0L, 123.0L, 123.0L, 123.0L},
-            {123.0L, 123.0L, 123.0L, 123.0L},
-            {123.0L, 123.0L, 123.0L, 123.0L},
+            {123.0, 123.0, 123.0, 123.0},
+            {123.0, 123.0, 123.0, 123.0},
+            {123.0, 123.0, 123.0, 123.0},
+            {123.0, 123.0, 123.0, 123.0},
     }};
 
     SUBCASE("2D") {
@@ -124,10 +124,10 @@ TEST_CASE_TEMPLATE("Construct matrix from single element fill", Type, VALID_TYPE
 
 TEST_CASE_TEMPLATE("Construct identity matrix", Type, VALID_TYPES) {
     constexpr TestGrid kExpected{{
-            {1.0L, 0.0L, 0.0L, 0.0L},
-            {0.0L, 1.0L, 0.0L, 0.0L},
-            {0.0L, 0.0L, 1.0L, 0.0L},
-            {0.0L, 0.0L, 0.0L, 1.0L},
+            {1.0, 0.0, 0.0, 0.0},
+            {0.0, 1.0, 0.0, 0.0},
+            {0.0, 0.0, 1.0, 0.0},
+            {0.0, 0.0, 0.0, 1.0},
     }};
 
 
@@ -166,11 +166,11 @@ TEST_CASE_TEMPLATE("Size", Type, VALID_TYPES) {
 
 TEST_CASE_TEMPLATE("Access elements by indices with at()", Type, VALID_TYPES) {
     constexpr TestGrid kInput{{
-                                         {1.0L, 2.0L, -3.5L, 0.0L},
-                                         {5.0L, 6.6L, 7.0L, -9.0L},
-                                         {-1.0L, -2.0L, 3.0L, -4.0L},
-                                         {-5.0L, -6.0L, 7.0L, -8.0L},
-                                 }};
+            {1.0, 2.0, -3.5, 0.0},
+            {5.0, 6.6, 7.0, -9.0},
+            {-1.0, -2.0, 3.0, -4.0},
+            {-5.0, -6.0, 7.0, -8.0},
+    }};
 
     SUBCASE("2D") {
         auto m = get_mat<Type, 2>(kInput);
@@ -182,6 +182,9 @@ TEST_CASE_TEMPLATE("Access elements by indices with at()", Type, VALID_TYPES) {
                 CHECK(m.at(i, j) == doctest::Approx(i + j));
             }
         }
+        // Out-of-bounds
+        CHECK_THROWS(m.at(1, 2));
+        CHECK_THROWS(m.at(2, 1));
     }
 
     SUBCASE("3D") {
@@ -194,6 +197,9 @@ TEST_CASE_TEMPLATE("Access elements by indices with at()", Type, VALID_TYPES) {
                 CHECK(m.at(i, j) == doctest::Approx(i + j));
             }
         }
+        // Out-of-bounds
+        CHECK_THROWS(m.at(2, 3));
+        CHECK_THROWS(m.at(3, 2));
     }
 
     SUBCASE("4D") {
@@ -206,15 +212,18 @@ TEST_CASE_TEMPLATE("Access elements by indices with at()", Type, VALID_TYPES) {
                 CHECK(m.at(i, j) == doctest::Approx(i + j));
             }
         }
+        // Out-of-bounds
+        CHECK_THROWS(m.at(3, 4));
+        CHECK_THROWS(m.at(4, 3));
     }
 }
 
 TEST_CASE_TEMPLATE("Access rows by index with at()", Type, VALID_TYPES) {
     constexpr TestGrid kInput{{
-            {1.0L, 2.0L, -3.5L, 0.0L},
-            {5.0L, 6.6L, 7.0L, -9.0L},
-            {-1.0L, -2.0L, 3.0L, -4.0L},
-            {-5.0L, -6.0L, 7.0L, -8.0L},
+            {1.0, 2.0, -3.5, 0.0},
+            {5.0, 6.6, 7.0, -9.0},
+            {-1.0, -2.0, 3.0, -4.0},
+            {-5.0, -6.0, 7.0, -8.0},
     }};
 
     SUBCASE("2D") {
@@ -259,13 +268,13 @@ TEST_CASE_TEMPLATE("Access rows by index with at()", Type, VALID_TYPES) {
 
 TEST_CASE_TEMPLATE("Begin/end iterator access", Type, VALID_TYPES) {
     constexpr TestGrid kInput{{
-            {1.0L, 2.0L, -3.5L, 0.0L},
-            {5.0L, 6.6L, 7.0L, -9.0L},
-            {-1.0L, -2.0L, 3.0L, -4.0L},
-            {-5.0L, -6.0L, 7.0L, -8.0L},
+            {1.0, 2.0, -3.5, 0.0},
+            {5.0, 6.6, 7.0, -9.0},
+            {-1.0, -2.0, 3.0, -4.0},
+            {-5.0, -6.0, 7.0, -8.0},
     }};
     constexpr Type kValue{static_cast<Type>(7)}; // arbitrary
-    constexpr TestArray kExpected{7.0L, 7.0L, 7.0L, 7.0L};
+    constexpr TestArray kExpected{7.0, 7.0, 7.0, 7.0};
 
     SUBCASE("2D") {
         auto m = get_mat<Type, 2>(kInput) ;
@@ -297,26 +306,26 @@ TEST_CASE_TEMPLATE("Begin/end iterator access", Type, VALID_TYPES) {
 
 TEST_CASE_TEMPLATE("Determinant", Type, VALID_TYPES) {
     constexpr TestGrid kInput{{
-            {1.0L, 2.0L, -3.5L, 0.0L},
-            {5.0L, 6.6L, 7.0L, -9.0L},
-            {-1.0L, -2.0L, 3.0L, -4.0L},
-            {-5.0L, -6.0L, 7.0L, -8.0L},
+            {1.0, 2.0, -3.5, 0.0},
+            {5.0, 6.6, 7.0, -9.0},
+            {-1.0, -2.0, 3.0, -4.0},
+            {-5.0, -6.0, 7.0, -8.0},
     }};
 
     SUBCASE("2D") {
-        constexpr Type kExpected{static_cast<Type>(-3.4L)};
+        constexpr Type kExpected{static_cast<Type>(-3.4)};
         constexpr auto m = get_mat<Type, 2>(kInput);
         CHECK(m.determinant() == doctest::Approx(kExpected));
     }
 
     SUBCASE("3D") {
-        constexpr Type kExpected{static_cast<Type>(1.7L)};
+        constexpr Type kExpected{static_cast<Type>(1.7)};
         constexpr auto m = get_mat<Type, 3>(kInput);
         CHECK(m.determinant() == doctest::Approx(kExpected));
     }
 
     SUBCASE("4D") {
-        constexpr Type kExpected{static_cast<Type>(-280.8L)};
+        constexpr Type kExpected{static_cast<Type>(-280.8)};
         constexpr auto m = get_mat<Type, 4>(kInput);
         CHECK(m.determinant() == doctest::Approx(kExpected));
     }
@@ -324,16 +333,16 @@ TEST_CASE_TEMPLATE("Determinant", Type, VALID_TYPES) {
 
 TEST_CASE_TEMPLATE("Transpose", Type, VALID_TYPES) {
     constexpr TestGrid kInput{{
-            {1.0L, 2.0L, -3.5L, 0.0L},
-            {5.0L, 6.6L, 7.0L, -9.0L},
-            {-1.0L, -2.0L, 3.0L, -4.0L},
-            {-5.0L, -6.0L, 7.0L, -8.0L},
+            {1.0, 2.0, -3.5, 0.0},
+            {5.0, 6.6, 7.0, -9.0},
+            {-1.0, -2.0, 3.0, -4.0},
+            {-5.0, -6.0, 7.0, -8.0},
     }};
     constexpr TestGrid kExpected{{
-            {1.0L, 5.0L, -1.0L, -5.0L},
-            {2.0L, 6.6L, -2.0L, -6.0L},
-            {-3.5L, 7.0L, 3.0L, 7.0L},
-            {0.0L, -9.0L, -4.0L, -8.0L},
+            {1.0, 5.0, -1.0, -5.0},
+            {2.0, 6.6, -2.0, -6.0},
+            {-3.5, 7.0, 3.0, 7.0},
+            {0.0, -9.0, -4.0, -8.0},
     }};
 
     SUBCASE("2D") {
@@ -357,57 +366,53 @@ TEST_CASE_TEMPLATE("Transpose", Type, VALID_TYPES) {
 
 TEST_CASE_TEMPLATE("Inverse", Type, VALID_TYPES) {
     constexpr TestGrid kInput{{
-            {1.0L, 2.0L, -3.5L, 0.0L},
-            {5.0L, 6.6L, 7.0L, -9.0L},
-            {-1.0L, -2.0L, 3.0L, -4.0L},
-            {-5.0L, -6.0L, 7.0L, -8.0L},
+            {1.0, 2.0, -3.5, 0.0},
+            {5.0, 6.6, 7.0, -9.0},
+            {-1.0, -2.0, 3.0, -4.0},
+            {-5.0, -6.0, 7.0, -8.0},
     }};
 
     SUBCASE("2D") {
         constexpr TestGrid kExpected{{
-                {-1.941176470588235294L,  0.58823529411764705882L},
-                { 1.470588235294117647L, -0.29411764705882352941L},
+                {-1.94117647,  0.58823529},
+                { 1.47058823, -0.29411764},
         }};
         constexpr auto m = get_mat<Type, 2>(kInput);
         constexpr auto m_inverse = m.inverse();
-        CHECK(m_inverse == get_mat<Type, 2>(kExpected));
+        CHECK(m_inverse == get_approx_mat<Type, 2>(kExpected));
     }
 
     SUBCASE("3D") {
         constexpr TestGrid kExpected{{
-                { 19.882352941176470588L,  0.58823529411764705882L,  21.823529411764705882L},
-                {-12.941176470588235294L, -0.29411764705882352941L, -14.411764705882352941L},
-                {-2.0L,                    0.0L,                    -2.0L},
+                { 19.88235294,  0.58823529,  21.82352941},
+                {-12.94117647, -0.29411764, -14.41176470},
+                {-2.0,          0.0,         -2.0},
         }};
         constexpr auto m = get_mat<Type, 3>(kInput);
         constexpr auto m_inverse = m.inverse();
-        CHECK(m_inverse == get_mat<Type, 3>(kExpected));
+        CHECK(m_inverse == get_approx_mat<Type, 3>(kExpected));
     }
 
     SUBCASE("4D") {
         constexpr TestGrid kExpected{{
-            {-0.165242169797420501698L, -0.071225073188543319702L,
-              1.281339066661894321420L, -0.560541325993835926045L},
-            { 0.113960117101669311523L,  0.135327639058232307434L,
-             -1.034544188063591718674L,  0.365028500091284513474L},
-            {-0.267806275188922882075L,  0.056980058550834655762L,
-             -0.225071231275796890253L,  0.048433049768209457398L},
-            {-0.216524222493171691886L, -0.007122507318854331970L,
-             -0.221866102982312440878L, -0.006054131221026182176L},
+            {-0.1652421, -0.07122507,  1.28133906, -0.56054132},
+            { 0.1139601,  0.13532763, -1.03454418,  0.36502850},
+            {-0.2678062,  0.05698005, -0.22507123,  0.04843304},
+            {-0.2165242, -0.00712250, -0.22186610, -0.00605414},
         }};
         constexpr auto m = get_mat<Type, 4>(kInput);
         constexpr auto m_inverse = m.inverse();
-        CHECK(m_inverse == get_mat<Type, 4>(kExpected));
+        CHECK(m_inverse == get_approx_mat<Type, 4>(kExpected));
     }
 }
 
 TEST_CASE_TEMPLATE("Fill", Type, VALID_TYPES) {
-    constexpr Type kFillValue{static_cast<Type>(123.0L)};
+    constexpr Type kFillValue{static_cast<Type>(123.0)};
     constexpr TestGrid kExpected{{
-            {123.0L, 123.0L, 123.0L, 123.0L},
-            {123.0L, 123.0L, 123.0L, 123.0L},
-            {123.0L, 123.0L, 123.0L, 123.0L},
-            {123.0L, 123.0L, 123.0L, 123.0L},
+            {123.0, 123.0, 123.0, 123.0},
+            {123.0, 123.0, 123.0, 123.0},
+            {123.0, 123.0, 123.0, 123.0},
+            {123.0, 123.0, 123.0, 123.0},
     }};
 
     SUBCASE("2D") {
@@ -434,12 +439,12 @@ TEST_CASE_TEMPLATE("Fill", Type, VALID_TYPES) {
 
 TEST_CASE_TEMPLATE("Clear", Type, VALID_TYPES) {
     // Shared input and expected output data
-    constexpr Type kFillValue{static_cast<Type>(123.0L)};
+    constexpr Type kFillValue{static_cast<Type>(123.0)};
     constexpr TestGrid kExpected{{
-            {0.0L, 0.0L, 0.0L, 0.0L},
-            {0.0L, 0.0L, 0.0L, 0.0L},
-            {0.0L, 0.0L, 0.0L, 0.0L},
-            {0.0L, 0.0L, 0.0L, 0.0L},
+            {0.0, 0.0, 0.0, 0.0},
+            {0.0, 0.0, 0.0, 0.0},
+            {0.0, 0.0, 0.0, 0.0},
+            {0.0, 0.0, 0.0, 0.0},
     }};
 
     SUBCASE("2D") {

--- a/tests/test_mat_operators.cpp
+++ b/tests/test_mat_operators.cpp
@@ -8,4 +8,581 @@
 // UUT headers
 #include "mat.hpp"
 
-// TODO
+TEST_CASE_TEMPLATE("Access rows by index with []", Type, VALID_TYPES) {
+    constexpr TestGrid kInput{{
+            {1.0, 2.0, -3.5, 0.0},
+            {5.0, 6.6, 7.0, -9.0},
+            {-1.0, -2.0, 3.0, -4.0},
+            {-5.0, -6.0, 7.0, -8.0},
+    }};
+
+    SUBCASE("2D") {
+        auto m = get_mat<Type, 2>(kInput);
+        for (size_t i = 0; i < 2; i++) {
+            // Read, write, and read again
+            CHECK(m[i] == get_approx_vec<Type, 2>(kInput[i]));
+            m[i].clear();
+            CHECK(m[i] == get_approx_vec<Type, 2>({}));
+        }
+    }
+
+    SUBCASE("3D") {
+        auto m = get_mat<Type, 3>(kInput);
+        for (size_t i = 0; i < 3; i++) {
+            // Read, write, and read again
+            CHECK(m[i] == get_approx_vec<Type, 3>(kInput[i]));
+            m[i].clear();
+            CHECK(m[i] == get_approx_vec<Type, 3>({}));
+        }
+    }
+
+    SUBCASE("4D") {
+        auto m = get_mat<Type, 4>(kInput);
+        for (size_t i = 0; i < 4; i++) {
+            // Read, write, and read again
+            CHECK(m[i] == get_approx_vec<Type, 4>(kInput[i]));
+            m[i].clear();
+            CHECK(m[i] == get_approx_vec<Type, 4>({}));
+        }
+    }
+}
+
+TEST_CASE_TEMPLATE("Access elements by indices with ()", Type, VALID_TYPES) {
+    constexpr TestGrid kInput{{
+            {1.0, 2.0, -3.5, 0.0},
+            {5.0, 6.6, 7.0, -9.0},
+            {-1.0, -2.0, 3.0, -4.0},
+            {-5.0, -6.0, 7.0, -8.0},
+    }};
+
+    SUBCASE("2D") {
+        auto m = get_mat<Type, 2>(kInput);
+        for (size_t i = 0; i < 2; i++) {
+            for (size_t j = 0; j < 2; j++) {
+                // Read, write, and read again
+                CHECK(m(i, j) == doctest::Approx(kInput[i][j]));
+                m(i, j) = (i + j);
+                CHECK(m(i, j) == doctest::Approx(i + j));
+            }
+        }
+    }
+
+    SUBCASE("3D") {
+        auto m = get_mat<Type, 3>(kInput);
+        for (size_t i = 0; i < 3; i++) {
+            for (size_t j = 0; j < 3; j++) {
+                // Read, write, and read again
+                CHECK(m(i, j) == doctest::Approx(kInput[i][j]));
+                m(i, j) = (i + j);
+                CHECK(m(i, j) == doctest::Approx(i + j));
+            }
+        }
+    }
+
+    SUBCASE("4D") {
+        auto m = get_mat<Type, 4>(kInput);
+        for (size_t i = 0; i < 4; i++) {
+            for (size_t j = 0; j < 4; j++) {
+                // Read, write, and read again
+                CHECK(m(i, j) == doctest::Approx(kInput[i][j]));
+                m(i, j) = (i + j);
+                CHECK(m(i, j) == doctest::Approx(i + j));
+            }
+        }
+    }
+}
+
+TEST_CASE_TEMPLATE("Matrix += matrix", Type, VALID_TYPES) {
+    constexpr TestGrid kInput1{{
+            {1.0, 2.0, -3.5, 0.0},
+            {5.0, 6.6, 7.0, -9.0},
+            {-1.0, -2.0, 3.0, -4.0},
+            {-5.0, -6.0, 7.0, -8.0},
+    }};
+    constexpr TestGrid kInput2{{
+            {1.0, 1.0, -2.0, -2.0},
+            {3.6, 3.6, 4.0, 4.0},
+            {-1.0, -1.0, -4.0, -4.0},
+            {-5.5, -5.5, 7.0, 7.0},
+    }};
+    constexpr TestGrid kExpected{{
+            {2.0, 3.0, -5.5, -2.0},
+            {8.6, 10.2, 11.0, -5.0},
+            {-2.0, -3.0, -1.0, -8.0},
+            {-10.5, -11.5, 14.0, -1.0},
+    }};
+
+    SUBCASE("2D") {
+        auto m1 = get_mat<Type, 2>(kInput1);
+        constexpr auto m2 = get_mat<Type, 2>(kInput2);
+        m1 += m2;
+        CHECK(m1 == get_approx_mat<Type, 2>(kExpected));
+    }
+
+    SUBCASE("3D") {
+        auto m1 = get_mat<Type, 3>(kInput1);
+        constexpr auto m2 = get_mat<Type, 3>(kInput2);
+        m1 += m2;
+        CHECK(m1 == get_approx_mat<Type, 3>(kExpected));
+    }
+
+    SUBCASE("4D") {
+        auto m1 = get_mat<Type, 4>(kInput1);
+        constexpr auto m2 = get_mat<Type, 4>(kInput2);
+        m1 += m2;
+        CHECK(m1 == get_approx_mat<Type, 4>(kExpected));
+    }
+}
+
+TEST_CASE_TEMPLATE("Matrix -= matrix", Type, VALID_TYPES) {
+    constexpr TestGrid kInput1{{
+            {1.0, 2.0, -3.5, 0.0},
+            {5.0, 6.6, 7.0, -9.0},
+            {-1.0, -2.0, 3.0, -4.0},
+            {-5.0, -6.0, 7.0, -8.0},
+    }};
+    constexpr TestGrid kInput2{{
+            {1.0, 1.0, -2.0, -2.0},
+            {3.6, 3.6, 4.0, 4.0},
+            {-1.0, -1.0, -4.0, -4.0},
+            {-5.5, -5.5, 7.0, 7.0},
+    }};
+    constexpr TestGrid kExpected{{
+            {0.0, 1.0, -1.5, 2.0},
+            {1.4, 3.0, 3.0, -13.0},
+            {0.0, -1.0, 7.0, 0.0},
+            {0.5, -0.5, 0.0, -15.0},
+    }};
+
+    SUBCASE("2D") {
+        auto m1 = get_mat<Type, 2>(kInput1);
+        constexpr auto m2 = get_mat<Type, 2>(kInput2);
+        m1 -= m2;
+        CHECK(m1 == get_approx_mat<Type, 2>(kExpected));
+    }
+
+    SUBCASE("3D") {
+        auto m1 = get_mat<Type, 3>(kInput1);
+        constexpr auto m2 = get_mat<Type, 3>(kInput2);
+        m1 -= m2;
+        CHECK(m1 == get_approx_mat<Type, 3>(kExpected));
+    }
+
+    SUBCASE("4D") {
+        auto m1 = get_mat<Type, 4>(kInput1);
+        constexpr auto m2 = get_mat<Type, 4>(kInput2);
+        m1 -= m2;
+        CHECK(m1 == get_approx_mat<Type, 4>(kExpected));
+    }
+}
+
+TEST_CASE_TEMPLATE("Matrix *= scalar", Type, VALID_TYPES) {
+    constexpr TestGrid kInput{{
+            {1.0, 2.0, -3.5, 0.0},
+            {5.0, 6.6, 7.0, -9.0},
+            {-1.0, -2.0, 3.0, -4.0},
+            {-5.0, -6.0, 7.0, -8.0},
+    }};
+    constexpr Type kScalar = static_cast<Type>(12.3);
+    constexpr TestGrid kExpected{{
+            {12.3, 24.6, -43.05, 0.0},
+            {61.5, 81.18, 86.1, -110.7},
+            {-12.3, -24.6, 36.9, -49.2},
+            {-61.5, -73.8, 86.1, -98.4},
+    }};
+
+    SUBCASE("2D") {
+        auto m = get_mat<Type, 2>(kInput);
+        m *= kScalar;
+        CHECK(m == get_approx_mat<Type, 2>(kExpected));
+    }
+
+    SUBCASE("3D") {
+        auto m = get_mat<Type, 3>(kInput);
+        m *= kScalar;
+        CHECK(m == get_approx_mat<Type, 3>(kExpected));
+    }
+
+    SUBCASE("4D") {
+        auto m = get_mat<Type, 4>(kInput);
+        m *= kScalar;
+        CHECK(m == get_approx_mat<Type, 4>(kExpected));
+    }
+}
+
+TEST_CASE_TEMPLATE("Matrix /= scalar", Type, VALID_TYPES) {
+    constexpr TestGrid kInput{{
+            {1.0, 2.0, -3.5, 0.0},
+            {5.0, 6.6, 7.0, -9.0},
+            {-1.0, -2.0, 3.0, -4.0},
+            {-5.0, -6.0, 7.0, -8.0},
+    }};
+    constexpr Type kScalar = static_cast<Type>(2.5);
+    constexpr TestGrid kExpected{{
+            {0.4, 0.8, -1.4, 0.0},
+            {2.0, 2.64, 2.8, -3.6},
+            {-0.4, -0.8, 1.2, -1.6},
+            {-2.0, -2.4, 2.8, -3.2},
+    }};
+
+    SUBCASE("2D") {
+        auto m = get_mat<Type, 2>(kInput);
+        m /= kScalar;
+        CHECK(m == Approx(get_mat<Type, 2>(kExpected)));
+    }
+
+    SUBCASE("3D") {
+        auto m = get_mat<Type, 3>(kInput);
+        m /= kScalar;
+        CHECK(m == Approx(get_mat<Type, 3>(kExpected)));
+    }
+
+    SUBCASE("4D") {
+        auto m = get_mat<Type, 4>(kInput);
+        m /= kScalar;
+        CHECK(m == Approx(get_mat<Type, 4>(kExpected)));
+    }
+}
+
+TEST_CASE_TEMPLATE("Negate (-matrix)", Type, VALID_TYPES) {
+    constexpr TestGrid kInput{{
+            {1.0, 2.0, -3.5, 0.0},
+            {5.0, 6.6, 7.0, -9.0},
+            {-1.0, -2.0, 3.0, -4.0},
+            {-5.0, -6.0, 7.0, -8.0},
+    }};
+    constexpr TestGrid kExpected{{
+            {-1.0, -2.0, 3.5, 0.0},
+            {-5.0, -6.6, -7.0, 9.0},
+            {1.0, 2.0, -3.0, 4.0},
+            {5.0, 6.0, -7.0, 8.0},
+    }};
+
+    SUBCASE("2D") {
+        constexpr auto m = get_mat<Type, 2>(kInput);
+        constexpr auto m_neg = -m;
+        CHECK(m_neg == get_approx_mat<Type, 2>(kExpected));
+    }
+
+    SUBCASE("3D") {
+        constexpr auto m = get_mat<Type, 3>(kInput);
+        constexpr auto m_neg = -m;
+        CHECK(m_neg == get_approx_mat<Type, 3>(kExpected));
+    }
+
+    SUBCASE("4D") {
+        constexpr auto m = get_mat<Type, 4>(kInput);
+        constexpr auto m_neg = -m;
+        CHECK(m_neg == get_approx_mat<Type, 4>(kExpected));
+    }
+}
+
+TEST_CASE_TEMPLATE("Matrix ==/!= matrix", Type, VALID_TYPES) {
+    constexpr TestGrid kInput{{
+            {1.0, 2.0, -3.5, 0.0},
+            {5.0, 6.6, 7.0, -9.0},
+            {-1.0, -2.0, 3.0, -4.0},
+            {-5.0, -6.0, 7.0, -8.0},
+    }};
+
+    SUBCASE("2D") {
+        // Check equality case
+        constexpr auto m1 = get_mat<Type, 2>(kInput);
+        constexpr auto m2 = get_mat<Type, 2>(kInput);
+        CHECK(m1 == m2);
+        CHECK_FALSE(m1 != m2);
+
+        // Check inequality cases
+        for (size_t i = 0; i < 2; i++) {
+            for (size_t j = 0; j < 2; j++) {
+                Mat<Type, 2> m2_modified = m2;
+                m2_modified(i, j) += 0.001L;
+                CHECK_FALSE(m1 == m2_modified);
+                CHECK(m1 != m2_modified);
+            }
+        }
+    }
+
+    SUBCASE("3D") {
+        // Check equality case
+        constexpr auto m1 = get_mat<Type, 3>(kInput);
+        constexpr auto m2 = get_mat<Type, 3>(kInput);
+        CHECK(m1 == m2);
+        CHECK_FALSE(m1 != m2);
+
+        // Check inequality cases
+        for (size_t i = 0; i < 3; i++) {
+            for (size_t j = 0; j < 3; j++) {
+                Mat<Type, 3> m2_modified = m2;
+                m2_modified(i, j) += 0.001L;
+                CHECK_FALSE(m1 == m2_modified);
+                CHECK(m1 != m2_modified);
+            }
+        }
+    }
+
+    SUBCASE("4D") {
+        // Check equality case
+        constexpr auto m1 = get_mat<Type, 4>(kInput);
+        constexpr auto m2 = get_mat<Type, 4>(kInput);
+        CHECK(m1 == m2);
+        CHECK_FALSE(m1 != m2);
+
+        // Check inequality cases
+        for (size_t i = 0; i < 4; i++) {
+            for (size_t j = 0; j < 4; j++) {
+                Mat<Type, 4> m2_modified = m2;
+                m2_modified(i, j) += 0.001L;
+                CHECK_FALSE(m1 == m2_modified);
+                CHECK(m1 != m2_modified);
+            }
+        }
+    }
+}
+
+TEST_CASE_TEMPLATE("Matrix + matrix", Type, VALID_TYPES) {
+    constexpr TestGrid kInput1{{
+            {1.0, 2.0, -3.5, 0.0},
+            {5.0, 6.6, 7.0, -9.0},
+            {-1.0, -2.0, 3.0, -4.0},
+            {-5.0, -6.0, 7.0, -8.0},
+    }};
+    constexpr TestGrid kInput2{{
+            {1.0, 1.0, -2.0, -2.0},
+            {3.6, 3.6, 4.0, 4.0},
+            {-1.0, -1.0, -4.0, -4.0},
+            {-5.5, -5.5, 7.0, 7.0},
+    }};
+    constexpr TestGrid kExpected{{
+            {2.0, 3.0, -5.5, -2.0},
+            {8.6, 10.2, 11.0, -5.0},
+            {-2.0, -3.0, -1.0, -8.0},
+            {-10.5, -11.5, 14.0, -1.0},
+    }};
+
+    SUBCASE("2D") {
+        constexpr auto m1 = get_mat<Type, 2>(kInput1);
+        constexpr auto m2 = get_mat<Type, 2>(kInput2);
+        constexpr Mat<Type, 2> m_sum = m1 + m2;
+        CHECK(m_sum == get_approx_mat<Type, 2>(kExpected));
+    }
+
+    SUBCASE("3D") {
+        constexpr auto m1 = get_mat<Type, 3>(kInput1);
+        constexpr auto m2 = get_mat<Type, 3>(kInput2);
+        constexpr Mat<Type, 3> m_sum = m1 + m2;
+        CHECK(m_sum == get_approx_mat<Type, 3>(kExpected));
+    }
+
+    SUBCASE("4D") {
+        constexpr auto m1 = get_mat<Type, 4>(kInput1);
+        constexpr auto m2 = get_mat<Type, 4>(kInput2);
+        constexpr Mat<Type, 4> m_sum = m1 + m2;
+        CHECK(m_sum == get_approx_mat<Type, 4>(kExpected));
+    }
+}
+
+TEST_CASE_TEMPLATE("Matrix - matrix", Type, VALID_TYPES) {
+    constexpr TestGrid kInput1{{
+            {1.0, 2.0, -3.5, 0.0},
+            {5.0, 6.6, 7.0, -9.0},
+            {-1.0, -2.0, 3.0, -4.0},
+            {-5.0, -6.0, 7.0, -8.0},
+    }};
+    constexpr TestGrid kInput2{{
+            {1.0, 1.0, -2.0, -2.0},
+            {3.6, 3.6, 4.0, 4.0},
+            {-1.0, -1.0, -4.0, -4.0},
+            {-5.5, -5.5, 7.0, 7.0},
+    }};
+    constexpr TestGrid kExpected{{
+            {0.0, 1.0, -1.5, 2.0},
+            {1.4, 3.0, 3.0, -13.0},
+            {0.0, -1.0, 7.0, 0.0},
+            {0.5, -0.5, 0.0, -15.0},
+    }};
+
+    SUBCASE("2D") {
+        constexpr auto m1 = get_mat<Type, 2>(kInput1);
+        constexpr auto m2 = get_mat<Type, 2>(kInput2);
+        constexpr Mat<Type, 2> m_diff = m1 - m2;
+        CHECK(m_diff == get_approx_mat<Type, 2>(kExpected));
+    }
+
+    SUBCASE("3D") {
+        constexpr auto m1 = get_mat<Type, 3>(kInput1);
+        constexpr auto m2 = get_mat<Type, 3>(kInput2);
+        constexpr Mat<Type, 3> m_diff = m1 - m2;
+        CHECK(m_diff == get_approx_mat<Type, 3>(kExpected));
+    }
+
+    SUBCASE("4D") {
+        constexpr auto m1 = get_mat<Type, 4>(kInput1);
+        constexpr auto m2 = get_mat<Type, 4>(kInput2);
+        constexpr Mat<Type, 4> m_diff = m1 - m2;
+        CHECK(m_diff == get_approx_mat<Type, 4>(kExpected));
+    }
+}
+
+TEST_CASE_TEMPLATE("Matrix * scalar", Type, VALID_TYPES) {
+    constexpr TestGrid kInput{{
+            {1.0, 2.0, -3.5, 0.0},
+            {5.0, 6.6, 7.0, -9.0},
+            {-1.0, -2.0, 3.0, -4.0},
+            {-5.0, -6.0, 7.0, -8.0},
+    }};
+    constexpr Type kScalar = static_cast<Type>(12.3);
+    constexpr TestGrid kExpected{{
+            {12.3, 24.6, -43.05, 0.0},
+            {61.5, 81.18, 86.1, -110.7},
+            {-12.3, -24.6, 36.9, -49.2},
+            {-61.5, -73.8, 86.1, -98.4},
+    }};
+
+    SUBCASE("2D") {
+        constexpr auto m = get_mat<Type, 2>(kInput);
+        constexpr Mat<Type, 2> m_mul = m * kScalar;
+        CHECK(m_mul == get_approx_mat<Type, 2>(kExpected));
+    }
+
+    SUBCASE("3D") {
+        constexpr auto m = get_mat<Type, 3>(kInput);
+        constexpr Mat<Type, 3> m_mul = m * kScalar;
+        CHECK(m_mul == get_approx_mat<Type, 3>(kExpected));
+    }
+
+    SUBCASE("4D") {
+        constexpr auto m = get_mat<Type, 4>(kInput);
+        constexpr Mat<Type, 4> m_mul = m * kScalar;
+        CHECK(m_mul == get_approx_mat<Type, 4>(kExpected));
+    }
+}
+
+TEST_CASE_TEMPLATE("Matrix * matrix", Type, VALID_TYPES) {
+    constexpr TestGrid kInput1{{
+            {1.0, 2.0, -3.5, 0.0},
+            {5.0, 6.6, 7.0, -9.0},
+            {-1.0, -2.0, 3.0, -4.0},
+            {-5.0, -6.0, 7.0, -8.0},
+    }};
+    constexpr TestGrid kInput2{{
+            {1.0, 1.0, -2.0, -2.0},
+            {3.6, 3.6, 4.0, 4.0},
+            {-1.0, -1.0, -4.0, -4.0},
+            {-5.5, -5.5, 7.0, 7.0},
+    }};
+
+
+    SUBCASE("2D") {
+        constexpr TestGrid kExpected{{
+                {8.2, 8.2},
+                {28.76, 28.76},
+        }};
+
+        constexpr auto m1 = get_mat<Type, 2>(kInput1);
+        constexpr auto m2 = get_mat<Type, 2>(kInput2);
+        constexpr Mat<Type, 2> m_prod = m1 * m2;
+        CHECK(m_prod == Approx(get_mat<Type, 2>(kExpected)));
+    }
+
+    SUBCASE("3D") {
+        constexpr TestGrid kExpected{{
+                {11.7, 11.7, 20.0},
+                {21.76, 21.76, -11.6},
+                {-11.2, -11.2, -18.0},
+        }};
+
+        constexpr auto m1 = get_mat<Type, 3>(kInput1);
+        constexpr auto m2 = get_mat<Type, 3>(kInput2);
+        constexpr Mat<Type, 3> m_prod = m1 * m2;
+        CHECK(m_prod == Approx(get_mat<Type, 3>(kExpected)));
+    }
+
+    SUBCASE("4D") {
+        constexpr TestGrid kExpected{{
+                {11.7, 11.7, 20.0, 20.0},
+                {71.26, 71.26, -74.6, -74.6},
+                {10.8, 10.8, -46.0, -46.0},
+                {10.4, 10.4, -98.0, -98.0},
+        }};
+
+        constexpr auto m1 = get_mat<Type, 4>(kInput1);
+        constexpr auto m2 = get_mat<Type, 4>(kInput2);
+        constexpr Mat<Type, 4> m_prod = m1 * m2;
+        CHECK(m_prod == Approx(get_mat<Type, 4>(kExpected)));
+    }
+}
+
+TEST_CASE_TEMPLATE("Matrix / scalar", Type, VALID_TYPES) {
+    constexpr TestGrid kInput{{
+            {1.0, 2.0, -3.5, 0.0},
+            {5.0, 6.6, 7.0, -9.0},
+            {-1.0, -2.0, 3.0, -4.0},
+            {-5.0, -6.0, 7.0, -8.0},
+    }};
+    constexpr Type kScalar = static_cast<Type>(2.5);
+    constexpr TestGrid kExpected{{
+            {0.4, 0.8, -1.4, 0.0},
+            {2.0, 2.64, 2.8, -3.6},
+            {-0.4, -0.8, 1.2, -1.6},
+            {-2.0, -2.4, 2.8, -3.2},
+    }};
+
+    SUBCASE("2D") {
+        constexpr auto m = get_mat<Type, 2>(kInput);
+        constexpr Mat<Type, 2> m_div = m / kScalar;
+        CHECK(m_div == Approx(get_mat<Type, 2>(kExpected)));
+    }
+
+    SUBCASE("3D") {
+        constexpr auto m = get_mat<Type, 3>(kInput);
+        constexpr Mat<Type, 3> m_div = m / kScalar;
+        CHECK(m_div == Approx(get_mat<Type, 3>(kExpected)));
+    }
+
+    SUBCASE("4D") {
+        constexpr auto m = get_mat<Type, 4>(kInput);
+        constexpr Mat<Type, 4> m_div = m / kScalar;
+        CHECK(m_div == Approx(get_mat<Type, 4>(kExpected)));
+    }
+}
+
+TEST_CASE_TEMPLATE("Ostream operator", Type, VALID_TYPES) {
+    constexpr TestGrid kInput{{
+            {1.0, 2.001, -3.5, 0.0},
+            {5.0, 6.6, 7.0, -9.0},
+            {-1.0, -2.0, 3.0, -4.0},
+            {-5.0, -6.0, 7.0, -8.0},
+    }};
+
+    // Configure output resolution
+    std::stringstream out;
+    out << std::fixed << std::setprecision(3);
+
+    SUBCASE("2D") {
+        const std::string kExpected{"\n[[  1.000  2.001  ]"
+                                    "\n [  5.000  6.600  ]]"};
+        constexpr auto v = get_mat<Type, 2>(kInput);
+        out << v;
+        CHECK(out.str() == kExpected);
+    }
+
+    SUBCASE("3D") {
+        const std::string kExpected{"\n[[  1.000  2.001  -3.500  ]"
+                                    "\n [  5.000  6.600  7.000  ]"
+                                    "\n [  -1.000  -2.000  3.000  ]]"};
+    constexpr auto v = get_mat<Type, 3>(kInput);
+        out << v;
+        CHECK(out.str() == kExpected);
+    }
+
+    SUBCASE("4D") {
+        const std::string kExpected{"\n[[  1.000  2.001  -3.500  0.000  ]"
+                                    "\n [  5.000  6.600  7.000  -9.000  ]"
+                                    "\n [  -1.000  -2.000  3.000  -4.000  ]"
+                                    "\n [  -5.000  -6.000  7.000  -8.000  ]]"};
+    constexpr auto v = get_mat<Type, 4>(kInput);
+        out << v;
+        CHECK(out.str() == kExpected);
+    }
+}

--- a/tests/test_test_utils.cpp
+++ b/tests/test_test_utils.cpp
@@ -31,12 +31,12 @@ TEST_CASE("Basic vector/helper tests to enable more comprehensive vector tests")
         constexpr Vec<float, kMaxSize> v1{5.1F, -6.024F, 0.0F, 8.99F};
         constexpr Vec<float, kMaxSize> v2{5.1F, -6.024F, 0.0F, 8.99F};
         constexpr float kDelta = 0.001F;
-        CHECK_APPROX_EQ(v1, v2);
+        CHECK(v1 == Approx(v2));
 
         for (size_t i = 0; i < kMaxSize; i++) {
             Vec<float, kMaxSize> v2_mod = v2;
             v2_mod[i] += kDelta;
-            CHECK_APPROX_NEQ(v1, v2_mod);
+            CHECK(v1 != Approx(v2_mod));
         }
     }
 }
@@ -59,10 +59,10 @@ TEST_CASE("Basic matrix/helper checks to enable more comprehensive matrix tests"
 
     SUBCASE("Helper get_mat()") {
         constexpr TestGrid kTestValues{{
-                {1.0L, 2.0L, 3.0L, 4.0L},
-                {5.0L, 6.0L, 7.0L, 8.0L},
-                {-1.0L, -2.0L, -3.0L, -4.0L},
-                {-5.0L, -6.0L, -7.0L, -8.0L}
+                {1.0, 2.0, 3.0, 4.0},
+                {5.0, 6.0, 7.0, 8.0},
+                {-1.0, -2.0, -3.0, -4.0},
+                {-5.0, -6.0, -7.0, -8.0}
         }};
         constexpr auto m = get_mat<float, kMaxSize>(kTestValues);
         for (size_t i = 0; i < kMaxSize; i++) {
@@ -81,13 +81,13 @@ TEST_CASE("Basic matrix/helper checks to enable more comprehensive matrix tests"
                                 {-1.0F, -2.0F, -3.0F, -4.0F},
                                 {-5.0F, -6.0F, -7.0F, -8.0F}};
         constexpr float kDelta = 0.001F;
-        CHECK_APPROX_EQ(m1, m2);
+        CHECK(m1 == Approx(m2));
 
         for (size_t i = 0; i < kMaxSize; i++) {
             for (size_t j = 0; j < kMaxSize; j++) {
                 Mat<float, kMaxSize> m2_mod = m2;
                 m2_mod(i, j) += kDelta;
-                CHECK_APPROX_NEQ(m1, m2_mod);
+                CHECK(m1 != Approx(m2_mod));
             }
         }
     }

--- a/tests/test_utils/test_utils.hpp
+++ b/tests/test_utils/test_utils.hpp
@@ -4,6 +4,7 @@
 
 #include <algorithm>
 #include <array>
+#include <cmath>
 
 #include "vec.hpp"
 #include "mat.hpp"
@@ -15,19 +16,51 @@ using vec::Mat;
 // Types to template test cases over
 #define VALID_TYPES  float, double, long double
 
-// Approximate (in)equality checks for vectors and matrices
-#define CHECK_APPROX_EQ(a, b) CHECK(approx_eq((a), (b), kTestEpsilon))
-#define CHECK_APPROX_NEQ(a, b) CHECK_FALSE(approx_eq((a), (b), kTestEpsilon))
-
 // Maximum vector/matrix size permitted
 static constexpr size_t kMaxSize = 4;
 
 // Floating-point comparison epsilon for test assertions
-static constexpr double kTestEpsilon = 1e-6;
+static constexpr long double kTestEpsilon = 1e-6L;
 
 // Test types for specifying input/output data for vectors and matrices
 using TestArray = std::array<long double, kMaxSize>;
 using TestGrid = std::array<TestArray, kMaxSize>;
+
+// Vector/matrix approximate comparison helper class (akin to doctest::Approx)
+// Enables approximate comparison with operator== and display of each side on failed assertions
+// TODO: use a concept to restrict Type in a more explicit fashion
+template <typename Type>
+class Approx {
+public:
+    constexpr explicit Approx(Type data)
+            : data_(data), epsilon_(kTestEpsilon) {}
+
+    // Set new epsilon for comparisons
+    void epsilon(long double eps_new) {
+        epsilon_ = eps_new;
+    }
+
+    friend constexpr bool operator==(const Type& lhs, const Approx& rhs) {
+        return approx_eq(lhs, rhs.data_, rhs.epsilon_);
+    }
+
+    friend constexpr bool operator==(const Approx& lhs, const Type& rhs) {
+        return approx_eq(lhs.data_, rhs, lhs.epsilon_);
+    }
+
+    friend constexpr bool operator==(const Approx& lhs, const Approx& rhs) {
+        return approx_eq(lhs.data_, rhs.data_, std::min(lhs.epsilon_, rhs.epsilon_));
+    }
+
+    friend std::ostream& operator<<(std::ostream& os, const Approx& rhs) {
+       os << rhs.data_;
+       return os;
+    }
+
+private:
+    Type data_;
+    long double epsilon_;
+};
 
 // Helper to create vector of specified type and size from provided test array
 template <typename Type, size_t M>
@@ -42,6 +75,12 @@ constexpr Vec<Type, M> get_vec(const TestArray& test_array) {
     return v;
 }
 
+// Helper to create approximate wrapper of test vector for equality checks
+template <typename Type, size_t M>
+constexpr Approx<Vec<Type, M>> get_approx_vec(const TestArray& test_array) {
+    return Approx(get_vec<Type, M>(test_array));
+}
+
 // Helper to create matrix of specified type and size from provided test grid
 template <typename Type, size_t M>
 constexpr Mat<Type, M> get_mat(const TestGrid& test_grid) {
@@ -52,4 +91,10 @@ constexpr Mat<Type, M> get_mat(const TestGrid& test_grid) {
     std::transform(test_grid.cbegin(), test_grid.cbegin() + M,
                    m.begin(), assign_row);
     return m;
+}
+
+// Helper to create approximate wrapper of test matrix for equality checks
+template <typename Type, size_t M>
+constexpr Approx<Mat<Type, M>> get_approx_mat(const TestGrid& test_grid) {
+    return Approx(get_mat<Type, M>(test_grid));
 }

--- a/tests/test_vec_operators.cpp
+++ b/tests/test_vec_operators.cpp
@@ -11,7 +11,7 @@
 // UUT headers
 #include "vec.hpp"
 
-TEST_CASE_TEMPLATE("Access elements by [] (all types)", Type, VALID_TYPES) {
+TEST_CASE_TEMPLATE("Access elements by []", Type, VALID_TYPES) {
     // Shared input data:
     constexpr TestArray kInput{1.0L, 2.0L, 3.0L, 4.0L};
     constexpr Type kOffset{static_cast<Type>(7)}; // arbitrary
@@ -153,7 +153,7 @@ TEST_CASE_TEMPLATE("Vector /= scalar", Type, VALID_TYPES) {
     }
 }
 
-TEST_CASE_TEMPLATE("Test -vector (all types)", Type, VALID_TYPES) {
+TEST_CASE_TEMPLATE("Negate (-vector)", Type, VALID_TYPES) {
     // Shared input and expected output data:
     constexpr TestArray kInput{1.0L, -22.1L, 0.0L, 3.9L};
     constexpr TestArray kExpected{-1.0L, 22.1L, 0.0L, -3.9L};


### PR DESCRIPTION
Add unit tests for all operators for the matrix class. Also add an
Approx class for vectors and matrices that works similarly to
doctest::Approx. Convert matrix tests to use this. Note that vector
tests still must be converted.

Resolves #10 