### PR TITLE
Clean up existing unit tests

### DIFF
--- a/tests/test_mat_basic.cpp
+++ b/tests/test_mat_basic.cpp
@@ -98,7 +98,7 @@ TEST_CASE_TEMPLATE("Construct matrix from other matrix", Type, VALID_TYPES) {
 
 TEST_CASE_TEMPLATE("Construct matrix from single element fill", Type, VALID_TYPES) {
     // Shared input and expected output data:
-    constexpr Type kFillValue{static_cast<Type>(123.0)};
+    constexpr Type kFillValue = 123.0;
     constexpr TestGrid kExpected{{
             {123.0, 123.0, 123.0, 123.0},
             {123.0, 123.0, 123.0, 123.0},
@@ -273,7 +273,7 @@ TEST_CASE_TEMPLATE("Begin/end iterator access", Type, VALID_TYPES) {
             {-1.0, -2.0, 3.0, -4.0},
             {-5.0, -6.0, 7.0, -8.0},
     }};
-    constexpr Type kValue{static_cast<Type>(7)}; // arbitrary
+    constexpr Type kValue = 7;
     constexpr TestArray kExpected{7.0, 7.0, 7.0, 7.0};
 
     SUBCASE("2D") {
@@ -313,19 +313,19 @@ TEST_CASE_TEMPLATE("Determinant", Type, VALID_TYPES) {
     }};
 
     SUBCASE("2D") {
-        constexpr Type kExpected{static_cast<Type>(-3.4)};
+        constexpr Type kExpected = -3.4;
         constexpr auto m = get_mat<Type, 2>(kInput);
         CHECK(m.determinant() == doctest::Approx(kExpected));
     }
 
     SUBCASE("3D") {
-        constexpr Type kExpected{static_cast<Type>(1.7)};
+        constexpr Type kExpected = 1.7;
         constexpr auto m = get_mat<Type, 3>(kInput);
         CHECK(m.determinant() == doctest::Approx(kExpected));
     }
 
     SUBCASE("4D") {
-        constexpr Type kExpected{static_cast<Type>(-280.8)};
+        constexpr Type kExpected = -280.8;
         constexpr auto m = get_mat<Type, 4>(kInput);
         CHECK(m.determinant() == doctest::Approx(kExpected));
     }
@@ -407,7 +407,7 @@ TEST_CASE_TEMPLATE("Inverse", Type, VALID_TYPES) {
 }
 
 TEST_CASE_TEMPLATE("Fill", Type, VALID_TYPES) {
-    constexpr Type kFillValue{static_cast<Type>(123.0)};
+    constexpr Type kFillValue = 123.0;
     constexpr TestGrid kExpected{{
             {123.0, 123.0, 123.0, 123.0},
             {123.0, 123.0, 123.0, 123.0},
@@ -439,7 +439,7 @@ TEST_CASE_TEMPLATE("Fill", Type, VALID_TYPES) {
 
 TEST_CASE_TEMPLATE("Clear", Type, VALID_TYPES) {
     // Shared input and expected output data
-    constexpr Type kFillValue{static_cast<Type>(123.0)};
+    constexpr Type kFillValue = 123.0;
     constexpr TestGrid kExpected{{
             {0.0, 0.0, 0.0, 0.0},
             {0.0, 0.0, 0.0, 0.0},

--- a/tests/test_mat_operators.cpp
+++ b/tests/test_mat_operators.cpp
@@ -442,19 +442,25 @@ TEST_CASE_TEMPLATE("Matrix * scalar", Type, VALID_TYPES) {
     SUBCASE("2D") {
         constexpr auto m = get_mat<Type, 2>(kInput);
         constexpr Mat<Type, 2> m_mul = m * kScalar;
+        constexpr Mat<Type, 2> m_mul_reverse = kScalar * m;
         CHECK(m_mul == get_approx_mat<Type, 2>(kExpected));
+        CHECK(m_mul_reverse == Approx(get_mat<Type, 2>(kExpected)));
     }
 
     SUBCASE("3D") {
         constexpr auto m = get_mat<Type, 3>(kInput);
         constexpr Mat<Type, 3> m_mul = m * kScalar;
+        constexpr Mat<Type, 3> m_mul_reverse = kScalar * m;
         CHECK(m_mul == get_approx_mat<Type, 3>(kExpected));
+        CHECK(m_mul_reverse == Approx(get_mat<Type, 3>(kExpected)));
     }
 
     SUBCASE("4D") {
         constexpr auto m = get_mat<Type, 4>(kInput);
         constexpr Mat<Type, 4> m_mul = m * kScalar;
+        constexpr Mat<Type, 4> m_mul_reverse = kScalar * m;
         CHECK(m_mul == get_approx_mat<Type, 4>(kExpected));
+        CHECK(m_mul_reverse == Approx(get_mat<Type, 4>(kExpected)));
     }
 }
 

--- a/tests/test_test_utils.cpp
+++ b/tests/test_test_utils.cpp
@@ -9,7 +9,7 @@
 
 TEST_CASE("Basic vector/helper tests to enable more comprehensive vector tests") {
     SUBCASE("Element access with []") {
-        constexpr float kScale = 123.0F; // arbitrary
+        constexpr float kScale = 123.0F;
         Vec<float, kMaxSize> v{0.0F, 1.0F, 2.0F, 3.0F};
         for (size_t i = 0; i < kMaxSize; i++) {
             // Read, write, read again
@@ -43,7 +43,7 @@ TEST_CASE("Basic vector/helper tests to enable more comprehensive vector tests")
 
 TEST_CASE("Basic matrix/helper checks to enable more comprehensive matrix tests") {
     SUBCASE("Element access with ()") {
-        constexpr float kScale = 123.0F; // arbitrary
+        constexpr float kScale = 123.0F;
         Mat<float, kMaxSize> m{{3.0F, 2.0F, 1.0F, 0.0F},
                                {4.0F, 3.0F, 2.0F, 1.0F},
                                {5.0F, 4.0F, 3.0F, 2.0F},

--- a/tests/test_vec_basic.cpp
+++ b/tests/test_vec_basic.cpp
@@ -9,8 +9,7 @@
 #include "vec.hpp"
 
 TEST_CASE_TEMPLATE("Construct zero vector", Type, VALID_TYPES) {
-    // Shared expected output data:
-    constexpr TestArray kExpected{0.0L, 0.0L, 0.0L, 0.0L};
+    constexpr TestArray kExpected{0.0, 0.0, 0.0, 0.0};
 
     SUBCASE("2D") {
         constexpr Vec<Type, 2> v{};
@@ -29,8 +28,7 @@ TEST_CASE_TEMPLATE("Construct zero vector", Type, VALID_TYPES) {
 }
 
 TEST_CASE_TEMPLATE("Construct vector from elements", Type, VALID_TYPES) {
-    // Shared expected output data:
-    constexpr TestArray kExpected{1.0L, 2.0L, 3.0L, 4.0L};
+    constexpr TestArray kExpected{1.0, 2.0, 3.0, 4.0};
 
     SUBCASE("2D") {
         constexpr Vec<Type, 2> v{static_cast<Type>(1),
@@ -55,9 +53,8 @@ TEST_CASE_TEMPLATE("Construct vector from elements", Type, VALID_TYPES) {
 }
 
 TEST_CASE_TEMPLATE("Construct vector from other vector", Type, VALID_TYPES) {
-    // Shared expected output data:
-    constexpr TestArray kInput{1.0L, 2.0L, 3.0L, 4.0L};
-    constexpr TestArray kExpected{1.0L, 2.0L, 3.0L, 4.0L};
+    constexpr TestArray kInput{1.0, 2.0, 3.0, 4.0};
+    constexpr TestArray kExpected{1.0, 2.0, 3.0, 4.0};
 
     SUBCASE("2D") {
         constexpr auto v = get_vec<Type, 2>(kInput);
@@ -79,9 +76,8 @@ TEST_CASE_TEMPLATE("Construct vector from other vector", Type, VALID_TYPES) {
 }
 
 TEST_CASE_TEMPLATE("Construct vector from single element fill", Type, VALID_TYPES) {
-    // Shared input and expected output data:
-    constexpr Type kFillValue{static_cast<Type>(123.0L)};
-    constexpr TestArray kExpected{123.0L, 123.0L, 123.0L, 123.0L};
+    constexpr Type kFillValue = 123.0;
+    constexpr TestArray kExpected{123.0, 123.0, 123.0, 123.0};
 
     SUBCASE("2D") {
         constexpr Vec<Type, 2> v_fill{kFillValue};
@@ -100,8 +96,7 @@ TEST_CASE_TEMPLATE("Construct vector from single element fill", Type, VALID_TYPE
 }
 
 TEST_CASE_TEMPLATE("Construct unit vector i", Type, VALID_TYPES) {
-    // Shared expected output data:
-    constexpr TestArray kExpected{1.0L, 0.0L, 0.0L, 0.0L};
+    constexpr TestArray kExpected{1.0, 0.0, 0.0, 0.0};
 
     SUBCASE("2D") {
         constexpr auto v_i = Vec<Type, 2>::i();
@@ -120,8 +115,7 @@ TEST_CASE_TEMPLATE("Construct unit vector i", Type, VALID_TYPES) {
 }
 
 TEST_CASE_TEMPLATE("Construct unit vector j", Type, VALID_TYPES) {
-    // Shared expected output data:
-    constexpr TestArray kExpected{0.0L, 1.0L, 0.0L, 0.0L};
+    constexpr TestArray kExpected{0.0, 1.0, 0.0, 0.0};
 
     SUBCASE("2D") {
         constexpr auto v_j = Vec<Type, 2>::j();
@@ -140,8 +134,7 @@ TEST_CASE_TEMPLATE("Construct unit vector j", Type, VALID_TYPES) {
 }
 
 TEST_CASE_TEMPLATE("Construct unit vector k", Type, VALID_TYPES) {
-    // Shared expected output data:
-    constexpr TestArray kExpected{0.0L, 0.0L, 1.0L, 0.0L};
+    constexpr TestArray kExpected{0.0, 0.0, 1.0, 0.0};
 
     SUBCASE("2D") {
         // Cannot represent unit vector k with a 2D vector
@@ -176,9 +169,8 @@ TEST_CASE_TEMPLATE("Size", Type, VALID_TYPES) {
 }
 
 TEST_CASE_TEMPLATE("Access elements by index with at()", Type, VALID_TYPES) {
-    // Shared input data:
-    constexpr TestArray kInput{1.0L, 2.0L, 3.0L, 4.0L};
-    constexpr Type kOffset{static_cast<Type>(7)}; // arbitrary
+    constexpr TestArray kInput{1.0, 2.0, 3.0, 4.0};
+    constexpr Type kOffset = 7;
 
     SUBCASE("2D") {
         auto v = get_vec<Type, 2>(kInput);
@@ -218,10 +210,9 @@ TEST_CASE_TEMPLATE("Access elements by index with at()", Type, VALID_TYPES) {
 }
 
 TEST_CASE_TEMPLATE("Begin/end iterator access", Type, VALID_TYPES) {
-    // Shared input data:
-    constexpr TestArray kInput{1.0L, 2.0L, 3.0L, 4.0L};
-    constexpr Type kValue{static_cast<Type>(7)}; // arbitrary
-    constexpr TestArray kExpected{7.0L, 7.0L, 7.0L, 7.0L};
+    constexpr TestArray kInput{1.0, 2.0, 3.0, 4.0};
+    constexpr Type kValue = 7;
+    constexpr TestArray kExpected{7.0, 7.0, 7.0, 7.0};
 
     SUBCASE("2D") {
         auto v = get_vec<Type, 2>(kInput);
@@ -249,171 +240,158 @@ TEST_CASE_TEMPLATE("Begin/end iterator access", Type, VALID_TYPES) {
 }
 
 TEST_CASE_TEMPLATE("Begin/end const iterator access", Type, VALID_TYPES) {
-    // Shared input data:
-    constexpr TestArray kInput{1.0L, 2.0L, 3.0L, 4.0L};
+    constexpr TestArray kInput{1.0, 2.0, 3.0, 4.0};
 
     SUBCASE("2D") {
         auto v = get_vec<Type, 2>(kInput);
-        CHECK(std::accumulate(v.cbegin(), v.cend(), 0) == doctest::Approx(3.0L));
+        CHECK(std::accumulate(v.cbegin(), v.cend(), 0) == doctest::Approx(3.0));
     }
 
     SUBCASE("3D") {
         auto v = get_vec<Type, 3>(kInput);
-        CHECK(std::accumulate(v.cbegin(), v.cend(), 0) == doctest::Approx(6.0L));
+        CHECK(std::accumulate(v.cbegin(), v.cend(), 0) == doctest::Approx(6.0));
     }
 
     SUBCASE("4D") {
         auto v = get_vec<Type, 4>(kInput);
-        CHECK(std::accumulate(v.cbegin(), v.cend(), 0) == doctest::Approx(10.0L));
+        CHECK(std::accumulate(v.cbegin(), v.cend(), 0) == doctest::Approx(10.0));
     }
 }
 
 TEST_CASE_TEMPLATE("Access elements by named x,y,z,w accessors", Type, VALID_TYPES) {
-    // Shared input data:
-    constexpr TestArray kInput{1.0L, 2.0L, 3.0L, 4.0L};
+    constexpr TestArray kInput{1.0, 2.0, 3.0, 4.0};
 
     SUBCASE("2D") {
         constexpr auto v = get_vec<Type, 2>(kInput);
-        CHECK(v.x() == doctest::Approx(1.0L));
-        CHECK(v.y() == doctest::Approx(2.0L));
+        CHECK(v.x() == doctest::Approx(1.0));
+        CHECK(v.y() == doctest::Approx(2.0));
         // Accessors for z and w are not available for 2D vectors
     }
 
     SUBCASE("3D") {
         constexpr auto v = get_vec<Type, 3>(kInput);
-        CHECK(v.x() == doctest::Approx(1.0L));
-        CHECK(v.y() == doctest::Approx(2.0L));
-        CHECK(v.z() == doctest::Approx(3.0L));
+        CHECK(v.x() == doctest::Approx(1.0));
+        CHECK(v.y() == doctest::Approx(2.0));
+        CHECK(v.z() == doctest::Approx(3.0));
         // Accessor for w is not available for 3D vectors
     }
 
     SUBCASE("4D") {
         constexpr auto v = get_vec<Type, 4>(kInput);
-        CHECK(v.x() == doctest::Approx(1.0L));
-        CHECK(v.y() == doctest::Approx(2.0L));
-        CHECK(v.z() == doctest::Approx(3.0L));
-        CHECK(v.w() == doctest::Approx(4.0L));
+        CHECK(v.x() == doctest::Approx(1.0));
+        CHECK(v.y() == doctest::Approx(2.0));
+        CHECK(v.z() == doctest::Approx(3.0));
+        CHECK(v.w() == doctest::Approx(4.0));
     }
 }
 
 TEST_CASE_TEMPLATE("Manhattan norm", Type, VALID_TYPES) {
-    // Shared input data:
-    constexpr TestArray kInput{0.4L, -2.1L, 0.0L, -3.0L};
+    constexpr TestArray kInput{0.4, -2.1, 0.0, -3.0};
 
     SUBCASE("2D") {
         constexpr auto v = get_vec<Type, 2>(kInput);
         constexpr Type len = v.manhattan();
-        CHECK(len == doctest::Approx(2.5L));
-        CHECK(v.manhattan() == doctest::Approx(2.5L)); // non-constexpr use
+        CHECK(len == doctest::Approx(2.5));
+        CHECK(v.manhattan() == doctest::Approx(2.5)); // non-constexpr use
     }
 
     SUBCASE("3D") {
         constexpr auto v = get_vec<Type, 3>(kInput);
         constexpr Type len = v.manhattan();
-        CHECK(len == doctest::Approx(2.5L));
-        CHECK(v.manhattan() == doctest::Approx(2.5L)); // non-constexpr use
+        CHECK(len == doctest::Approx(2.5));
+        CHECK(v.manhattan() == doctest::Approx(2.5)); // non-constexpr use
     }
 
     SUBCASE("4D") {
         constexpr auto v = get_vec<Type, 4>(kInput);
         constexpr Type len = v.manhattan();
-        CHECK(len == doctest::Approx(5.5L));
-        CHECK(v.manhattan() == doctest::Approx(5.5L)); // non-constexpr use
+        CHECK(len == doctest::Approx(5.5));
+        CHECK(v.manhattan() == doctest::Approx(5.5)); // non-constexpr use
     }
 }
 
 TEST_CASE_TEMPLATE("Euclidean norm", Type, VALID_TYPES) {
-    // Shared input data:
-    constexpr TestArray kInput{0.4L, -2.1L, 0.0L, -3.0L};
+    constexpr TestArray kInput{0.4, -2.1, 0.0, -3.0};
 
     SUBCASE("2D") {
         constexpr auto v = get_vec<Type, 2>(kInput);
         constexpr Type len = v.euclidean();
-        CHECK(len == doctest::Approx(2.13775L));
-        CHECK(v.euclidean() == doctest::Approx(2.13775L)); // non-constexpr use
+        CHECK(len == doctest::Approx(2.13775));
+        CHECK(v.euclidean() == doctest::Approx(2.13775)); // non-constexpr use
     }
 
     SUBCASE("3D") {
         constexpr auto v = get_vec<Type, 3>(kInput);
         constexpr Type len = v.euclidean();
-        CHECK(len == doctest::Approx(2.13775L));
-        CHECK(v.euclidean() == doctest::Approx(2.13775L)); // non-constexpr use
+        CHECK(len == doctest::Approx(2.13775));
+        CHECK(v.euclidean() == doctest::Approx(2.13775)); // non-constexpr use
     }
 
     SUBCASE("4D") {
         constexpr auto v = get_vec<Type, 4>(kInput);
         constexpr Type len = v.euclidean();
-        CHECK(len == doctest::Approx(3.68374L));
-        CHECK(v.euclidean() == doctest::Approx(3.68374L)); // non-constexpr use
+        CHECK(len == doctest::Approx(3.68374));
+        CHECK(v.euclidean() == doctest::Approx(3.68374)); // non-constexpr use
     }
 }
 
 TEST_CASE_TEMPLATE("Euclidean norm squared", Type, VALID_TYPES) {
-    // Shared input data:
-    constexpr TestArray kInput{0.4L, -2.1L, 0.0L, -3.0L};
+    constexpr TestArray kInput{0.4, -2.1, 0.0, -3.0};
 
     SUBCASE("2D") {
         constexpr auto v = get_vec<Type, 2>(kInput);
         constexpr Type len2 = v.euclidean2();
-        CHECK(len2 == doctest::Approx(4.57L));
-        CHECK(v.euclidean2() == doctest::Approx(4.57L)); // non-constexpr use
+        CHECK(len2 == doctest::Approx(4.57));
+        CHECK(v.euclidean2() == doctest::Approx(4.57)); // non-constexpr use
     }
 
     SUBCASE("3D") {
         constexpr auto v = get_vec<Type, 3>(kInput);
         constexpr Type len2 = v.euclidean2();
-        CHECK(len2 == doctest::Approx(4.57L));
-        CHECK(v.euclidean2() == doctest::Approx(4.57L)); // non-constexpr use
+        CHECK(len2 == doctest::Approx(4.57));
+        CHECK(v.euclidean2() == doctest::Approx(4.57)); // non-constexpr use
     }
 
     SUBCASE("4D") {
         constexpr auto v = get_vec<Type, 4>(kInput);
         constexpr Type len2 = v.euclidean2();
-        CHECK(len2 == doctest::Approx(13.57L));
-        CHECK(v.euclidean2() == doctest::Approx(13.57L)); // non-constexpr use
+        CHECK(len2 == doctest::Approx(13.57));
+        CHECK(v.euclidean2() == doctest::Approx(13.57)); // non-constexpr use
     }
 }
 
 TEST_CASE_TEMPLATE("Normalize", Type, VALID_TYPES) {
-    // Shared input data:
-    constexpr TestArray kInput{0.45L, -2.1L, 0.0L, -3.0L};
+    constexpr TestArray kInput{0.45, -2.1, 0.0, -3.0};
 
     SUBCASE("2D") {
-        constexpr TestArray kExpected{0.209529088730873460806321L,
-                                      -0.977802414077409483771867L};
+        constexpr TestArray kExpected{ 0.2095290887, -0.9778024140};
         constexpr auto v = get_vec<Type, 2>(kInput);
         constexpr Vec<Type, 2> v_normalized = v.normalize();
-        CHECK(v_normalized == get_vec<Type, 2>(kExpected));
-        CHECK(v.normalize() == get_vec<Type, 2>(kExpected)); // non-constexpr use
+        CHECK(v_normalized == get_approx_vec<Type, 2>(kExpected));
+        CHECK(v.normalize() == get_approx_vec<Type, 2>(kExpected)); // non-constexpr use
     }
 
     SUBCASE("3D") {
-        constexpr TestArray kExpected{0.209529088730873460806321L,
-                                      -0.977802414077409483771867L,
-                                      0.000000000000000000000000L};
+        constexpr TestArray kExpected{ 0.2095290887, -0.9778024140, 0.0000000000};
         constexpr auto v = get_vec<Type, 3>(kInput);
         constexpr Vec<Type, 3> v_normalized = v.normalize();
-        CHECK(v_normalized == get_vec<Type, 3>(kExpected));
-        CHECK(v.normalize() == get_vec<Type, 3>(kExpected)); // non-constexpr use
+        CHECK(v_normalized == get_approx_vec<Type, 3>(kExpected));
+        CHECK(v.normalize() == get_approx_vec<Type, 3>(kExpected)); // non-constexpr use
     }
 
     SUBCASE("4D") {
-        constexpr TestArray kExpected{0.121967344227261256164733L,
-                                      -0.569180939727219195448972L,
-                                      0.000000000000000000000000L,
-                                      -0.813115628181741707791990L};
+        constexpr TestArray kExpected{ 0.1219673442, -0.5691809397, 0.0000000000, -0.8131156281};
 
         constexpr auto v = get_vec<Type, 4>(kInput);
         constexpr Vec<Type, 4> v_normalized = v.normalize();
-        CHECK(v_normalized == get_vec<Type, 4>(kExpected));
-        CHECK(v.normalize() == get_vec<Type, 4>(kExpected)); // non-constexpr use
+        CHECK(v_normalized == get_approx_vec<Type, 4>(kExpected));
+        CHECK(v.normalize() == get_approx_vec<Type, 4>(kExpected)); // non-constexpr use
     }
 }
 
 TEST_CASE_TEMPLATE("Fill", Type, VALID_TYPES) {
-    // Shared input and expected output data
-    constexpr Type kFillValue{static_cast<Type>(123.0L)};
-    constexpr TestArray kExpected{123.0L, 123.0L, 123.0L, 123.0L};
+    constexpr Type kFillValue = 123.0;
+    constexpr TestArray kExpected{123.0, 123.0, 123.0, 123.0};
 
     SUBCASE("2D") {
         Vec<Type, 2> v{};
@@ -438,9 +416,8 @@ TEST_CASE_TEMPLATE("Fill", Type, VALID_TYPES) {
 }
 
 TEST_CASE_TEMPLATE("Clear", Type, VALID_TYPES) {
-    // Shared input and expected output data
-    constexpr Type kFillValue{static_cast<Type>(123.0L)};
-    constexpr TestArray kExpected{0.0L, 0.0L, 0.0L, 0.0L};
+    constexpr Type kFillValue = 123.0;
+    constexpr TestArray kExpected{0.0, 0.0, 0.0, 0.0};
 
     SUBCASE("2D") {
        Vec<Type, 2> v{kFillValue};

--- a/tests/test_vec_friends.cpp
+++ b/tests/test_vec_friends.cpp
@@ -9,8 +9,8 @@
 #include "vec.hpp"
 
 TEST_CASE_TEMPLATE("Approximate equality", Type, VALID_TYPES) {
-    constexpr TestArray kInput1{1.0L, 2.1L, -3.0L, 4.5L};
-    constexpr TestArray kInput2{1.0001L, 2.1L, -3.0L, 4.5L};
+    constexpr TestArray kInput1{1.0, 2.1, -3.0, 4.5};
+    constexpr TestArray kInput2{1.0001, 2.1, -3.0, 4.5};
 
     SUBCASE("4D - Self") {
         constexpr auto v1 = get_vec<Type, 4>(kInput1);
@@ -22,23 +22,22 @@ TEST_CASE_TEMPLATE("Approximate equality", Type, VALID_TYPES) {
         constexpr auto v1 = get_vec<Type, 4>(kInput1);
         constexpr auto v2 = get_vec<Type, 4>(kInput2);
         constexpr bool default_eps_eq = approx_eq(v1, v2);
-        constexpr bool custom_eps_eq = approx_eq(v1, v2, static_cast<Type>(0.001));
+        constexpr bool custom_eps_eq = approx_eq(v1, v2, 0.001);
         CHECK_FALSE(default_eps_eq);
         CHECK(custom_eps_eq);
     }
 }
 
 TEST_CASE_TEMPLATE("Dot product", Type, VALID_TYPES) {
-    // Shared input data:
-    constexpr TestArray kInput1{1.0L, 2.1L, -3.0L, 4.5L};
-    constexpr TestArray kInput2{-5.0L, 6.9L, 7.0L, 8.2L};
+    constexpr TestArray kInput1{1.0, 2.1, -3.0, 4.5};
+    constexpr TestArray kInput2{-5.0, 6.9, 7.0, 8.2};
 
     SUBCASE("2D") {
         constexpr auto v1 = get_vec<Type, 2>(kInput1);
         constexpr auto v2 = get_vec<Type, 2>(kInput2);
         constexpr Type v1_dot_v2 = dot(v1, v2);
         constexpr Type v2_dot_v1 = dot(v2, v1);
-        CHECK(v1_dot_v2 == doctest::Approx(9.49L));
+        CHECK(v1_dot_v2 == doctest::Approx(9.49));
         CHECK(v1_dot_v2 == v2_dot_v1);
     }
 
@@ -47,7 +46,7 @@ TEST_CASE_TEMPLATE("Dot product", Type, VALID_TYPES) {
         constexpr auto v2 = get_vec<Type, 3>(kInput2);
         constexpr Type v1_dot_v2 = dot(v1, v2);
         constexpr Type v2_dot_v1 = dot(v2, v1);
-        CHECK(v1_dot_v2 == doctest::Approx(-11.51L));
+        CHECK(v1_dot_v2 == doctest::Approx(-11.51));
         CHECK(v1_dot_v2 == v2_dot_v1);
     }
 
@@ -56,285 +55,263 @@ TEST_CASE_TEMPLATE("Dot product", Type, VALID_TYPES) {
         constexpr auto v2 = get_vec<Type, 4>(kInput2);
         constexpr Type v1_dot_v2 = dot(v1, v2);
         constexpr Type v2_dot_v1 = dot(v2, v1);
-        CHECK(v1_dot_v2 == doctest::Approx(25.39L));
+        CHECK(v1_dot_v2 == doctest::Approx(25.39));
         CHECK(v1_dot_v2 == v2_dot_v1);
     }
 }
 
 TEST_CASE_TEMPLATE("Cross product", Type, VALID_TYPES) {
-    // Shared input data:
-    constexpr TestArray kInput1{1.1L, 2.0L, 3.6L};
-    constexpr TestArray kInput2{-4.0L, 5.9L, 6.0L};
+    constexpr TestArray kInput1{1.1, 2.0, 3.6};
+    constexpr TestArray kInput2{-4.0, 5.9, 6.0};
     constexpr auto v1 = get_vec<Type, 3>(kInput1);
     constexpr auto v2 = get_vec<Type, 3>(kInput2);
 
     SUBCASE("Arbitrary") {
-        constexpr TestArray kExpected{-9.24L, -21.0L, 14.49L};
+        constexpr TestArray kExpected{-9.24, -21.0, 14.49};
         constexpr Vec<Type, 3> v1_cross_v2 = cross(v1, v2);
-        CHECK(v1_cross_v2 == get_vec<Type, 3>(kExpected));
+        CHECK(v1_cross_v2 == get_approx_vec<Type, 3>(kExpected));
     }
 
     SUBCASE("Arbitrary reverse order") {
-        constexpr TestArray kExpected{9.24L, 21.0L, -14.49L};
+        constexpr TestArray kExpected{9.24, 21.0, -14.49};
         constexpr Vec<Type, 3> v2_cross_v1 = cross(v2, v1);
-        CHECK(v2_cross_v1 == get_vec<Type, 3>(kExpected));
+        CHECK(v2_cross_v1 == get_approx_vec<Type, 3>(kExpected));
     }
 
     SUBCASE("Self") {
-        constexpr TestArray kExpected{0.0L, 0.0L, 0.0L};
+        constexpr TestArray kExpected{0.0, 0.0, 0.0};
         constexpr Vec<Type, 3> v1_cross_v1 = cross(v1, v1);
-        CHECK(v1_cross_v1 == get_vec<Type, 3>(kExpected));
+        CHECK(v1_cross_v1 == get_approx_vec<Type, 3>(kExpected));
     }
 }
 
 TEST_CASE_TEMPLATE("Manhattan distance", Type, VALID_TYPES) {
-    // Shared input data:
-    constexpr TestArray kInput1{1.0L, -2.1L, 3.5L, 4.0L};
-    constexpr TestArray kInput2{-5.0L, 6.0L, 7.2L, 8.2L};
+    constexpr TestArray kInput1{1.0, -2.1, 3.5, 4.0};
+    constexpr TestArray kInput2{-5.0, 6.0, 7.2, 8.2};
 
     SUBCASE("2D") {
         constexpr auto v1 = get_vec<Type, 2>(kInput1);
         constexpr auto v2 = get_vec<Type, 2>(kInput2);
         constexpr Type distance = manhattan(v1, v2);
-        CHECK(distance == doctest::Approx(14.1L));
-        CHECK(manhattan(v1, v2) == doctest::Approx(14.1L)); // non-constexpr use
+        CHECK(distance == doctest::Approx(14.1));
+        CHECK(manhattan(v1, v2) == doctest::Approx(14.1)); // non-constexpr use
     }
 
     SUBCASE("3D") {
         constexpr auto v1 = get_vec<Type, 3>(kInput1);
         constexpr auto v2 = get_vec<Type, 3>(kInput2);
         constexpr Type distance = manhattan(v1, v2);
-        CHECK(distance == doctest::Approx(17.8L));
-        CHECK(manhattan(v1, v2) == doctest::Approx(17.8L)); // non-constexpr use
+        CHECK(distance == doctest::Approx(17.8));
+        CHECK(manhattan(v1, v2) == doctest::Approx(17.8)); // non-constexpr use
     }
 
     SUBCASE("4D") {
         constexpr auto v1 = get_vec<Type, 4>(kInput1);
         constexpr auto v2 = get_vec<Type, 4>(kInput2);
         constexpr Type distance = manhattan(v1, v2);
-        CHECK(distance == doctest::Approx(22.0L));
-        CHECK(manhattan(v1, v2) == doctest::Approx(22.0L)); // non-constexpr use
+        CHECK(distance == doctest::Approx(22.0));
+        CHECK(manhattan(v1, v2) == doctest::Approx(22.0)); // non-constexpr use
     }
 }
 
 TEST_CASE_TEMPLATE("Euclidean distance", Type, VALID_TYPES) {
-    // Shared input data:
-    constexpr TestArray kInput1{1.0L, -2.1L, 3.5L, 4.0L};
-    constexpr TestArray kInput2{-5.0L, 6.0L, 7.2L, 8.2L};
+    constexpr TestArray kInput1{1.0, -2.1, 3.5, 4.0};
+    constexpr TestArray kInput2{-5.0, 6.0, 7.2, 8.2};
 
     SUBCASE("2D") {
         constexpr auto v1 = get_vec<Type, 2>(kInput1);
         constexpr auto v2 = get_vec<Type, 2>(kInput2);
         constexpr Type distance = euclidean(v1, v2);
-        CHECK(distance == doctest::Approx(10.0801785698L));
-        CHECK(euclidean(v1, v2) == doctest::Approx(10.0801785698L)); // non-constexpr use
+        CHECK(distance == doctest::Approx(10.0801785698));
+        CHECK(euclidean(v1, v2) == doctest::Approx(10.0801785698)); // non-constexpr use
     }
 
     SUBCASE("3D") {
         constexpr auto v1 = get_vec<Type, 3>(kInput1);
         constexpr auto v2 = get_vec<Type, 3>(kInput2);
         constexpr Type distance = euclidean(v1, v2);
-        CHECK(distance == doctest::Approx(10.7377837564L));
-        CHECK(euclidean(v1, v2) == doctest::Approx(10.7377837564L)); // non-constexpr use
+        CHECK(distance == doctest::Approx(10.7377837564));
+        CHECK(euclidean(v1, v2) == doctest::Approx(10.7377837564)); // non-constexpr use
     }
 
     SUBCASE("4D") {
         constexpr auto v1 = get_vec<Type, 4>(kInput1);
         constexpr auto v2 = get_vec<Type, 4>(kInput2);
         constexpr Type distance = euclidean(v1, v2);
-        CHECK(distance == doctest::Approx(11.5299609713L));
-        CHECK(euclidean(v1, v2) == doctest::Approx(11.5299609713L)); // non-constexpr use
+        CHECK(distance == doctest::Approx(11.5299609713));
+        CHECK(euclidean(v1, v2) == doctest::Approx(11.5299609713)); // non-constexpr use
     }
 }
 
 TEST_CASE_TEMPLATE("Euclidean distance squared", Type, VALID_TYPES) {
-    // Shared input data:
-    constexpr TestArray kInput1{1.0L, -2.1L, 3.5L, 4.0L};
-    constexpr TestArray kInput2{-5.0L, 6.0L, 7.2L, 8.2L};
+    constexpr TestArray kInput1{1.0, -2.1, 3.5, 4.0};
+    constexpr TestArray kInput2{-5.0, 6.0, 7.2, 8.2};
 
     SUBCASE("2D") {
         constexpr auto v1 = get_vec<Type, 2>(kInput1);
         constexpr auto v2 = get_vec<Type, 2>(kInput2);
         constexpr Type distance = euclidean2(v1, v2);
-        CHECK(distance == doctest::Approx(101.61L));
-        CHECK(euclidean2(v1, v2) == doctest::Approx(101.61L)); // non-constexpr use
+        CHECK(distance == doctest::Approx(101.61));
+        CHECK(euclidean2(v1, v2) == doctest::Approx(101.61)); // non-constexpr use
     }
 
     SUBCASE("3D") {
         constexpr auto v1 = get_vec<Type, 3>(kInput1);
         constexpr auto v2 = get_vec<Type, 3>(kInput2);
         constexpr Type distance = euclidean2(v1, v2);
-        CHECK(distance == doctest::Approx(115.3L));
-        CHECK(euclidean2(v1, v2) == doctest::Approx(115.3L)); // non-constexpr use
+        CHECK(distance == doctest::Approx(115.3));
+        CHECK(euclidean2(v1, v2) == doctest::Approx(115.3)); // non-constexpr use
     }
 
     SUBCASE("4D") {
         constexpr auto v1 = get_vec<Type, 4>(kInput1);
         constexpr auto v2 = get_vec<Type, 4>(kInput2);
         constexpr Type distance = euclidean2(v1, v2);
-        CHECK(distance == doctest::Approx(132.94L));
-        CHECK(euclidean2(v1, v2) == doctest::Approx(132.94L)); // non-constexpr use
+        CHECK(distance == doctest::Approx(132.94));
+        CHECK(euclidean2(v1, v2) == doctest::Approx(132.94)); // non-constexpr use
     }
 }
 
 TEST_CASE_TEMPLATE("Vector triple product", Type, VALID_TYPES) {
-    // Shared input data:
-    constexpr TestArray kInput1{1.1L, 2.0L, 3.6L};
-    constexpr TestArray kInput2{-4.0L, 5.9L, 6.0L};
-    constexpr TestArray kInput3{0.0L, 7.0L, -1.1L};
-    constexpr TestArray kExpected{-40.16L, -143.764L, 92.14L};
+    constexpr TestArray kInput1{1.1, 2.0, 3.6};
+    constexpr TestArray kInput2{-4.0, 5.9, 6.0};
+    constexpr TestArray kInput3{0.0, 7.0, -1.1};
+    constexpr TestArray kExpected{-40.16, -143.764, 92.14};
     constexpr auto v1 = get_vec<Type, 3>(kInput1);
     constexpr auto v2 = get_vec<Type, 3>(kInput2);
     constexpr auto v3 = get_vec<Type, 3>(kInput3);
 
     // Only defined for 3D vectors
-    CHECK(vector_triple(v1, v2, v3) == get_vec<Type, 3>(kExpected));
+    CHECK(vector_triple(v1, v2, v3) == get_approx_vec<Type, 3>(kExpected));
 }
 
 TEST_CASE_TEMPLATE("Scalar triple product", Type, VALID_TYPES) {
-    // Shared input data:
-    constexpr TestArray kInput1{1.1L, 2.0L, 3.6L};
-    constexpr TestArray kInput2{-4.0L, 5.9L, 6.0L};
-    constexpr TestArray kInput3{0.0L, 7.0L, -1.1L};
+    constexpr TestArray kInput1{1.1, 2.0, 3.6};
+    constexpr TestArray kInput2{-4.0, 5.9, 6.0};
+    constexpr TestArray kInput3{0.0, 7.0, -1.1};
     constexpr auto v1 = get_vec<Type, 3>(kInput1);
     constexpr auto v2 = get_vec<Type, 3>(kInput2);
     constexpr auto v3 = get_vec<Type, 3>(kInput3);
-    constexpr Type kExpected{-162.939L};
+    constexpr Type kExpected{-162.939};
 
     // Only defined for 3D vectors
     CHECK(scalar_triple(v1, v2, v3) == doctest::Approx(kExpected));
 }
 
 TEST_CASE_TEMPLATE("Project onto", Type, VALID_TYPES) {
-    // Shared input data:
-    constexpr TestArray kInput1{1.0L, -2.1L, 3.5L, 4.0L};
-    constexpr TestArray kInput2{-5.0L, 6.0L, 7.2L, 8.2L};
+    constexpr TestArray kInput1{1.0, -2.1, 3.5, 4.0};
+    constexpr TestArray kInput2{-5.0, 6.0, 7.2, 8.2};
 
     SUBCASE("2D") {
         // Note: higher resolution provided for operator== check below
-        constexpr TestArray kExpected{1.442622950819672130980467L,
-                                      -1.731147540983606557284981L};
+        constexpr TestArray kExpected{1.4426229508, -1.7311475409};
         constexpr auto v1 = get_vec<Type, 2>(kInput1);
         constexpr auto v2 = get_vec<Type, 2>(kInput2);
         constexpr Vec<Type, 2> v1_proj_v2 = project_onto(v1, v2);
-        CHECK(v1_proj_v2 == get_vec<Type, 2>(kExpected));
+        CHECK(v1_proj_v2 == get_approx_vec<Type, 2>(kExpected));
     }
 
     SUBCASE("3D") {
-        constexpr TestArray kExpected{-0.336760014179369018084758L,
-                                      0.404112017015242821723394L,
-                                      0.484934420418291386046389L};
+        constexpr TestArray kExpected{-0.3367600141, 0.4041120170, 0.4849344204};
         constexpr auto v1 = get_vec<Type, 3>(kInput1);
         constexpr auto v2 = get_vec<Type, 3>(kInput2);
         constexpr Vec<Type, 3> v1_proj_v2 = project_onto(v1, v2);
-        CHECK(v1_proj_v2 == get_vec<Type, 3>(kExpected));
+        CHECK(v1_proj_v2 == get_approx_vec<Type, 3>(kExpected));
     }
 
     SUBCASE("4D") {
-        constexpr TestArray kExpected{-1.121723678365171035205619L,
-                                      1.346068414038205242225059L,
-                                      1.615282096845846290713439L,
-                                      1.839626832518880497624458L};
+        constexpr TestArray kExpected{-1.1217236783, 1.3460684140, 1.6152820968, 1.8396268325};
         constexpr auto v1 = get_vec<Type, 4>(kInput1);
         constexpr auto v2 = get_vec<Type, 4>(kInput2);
         constexpr Vec<Type, 4> v1_proj_v2 = project_onto(v1, v2);
-        CHECK(v1_proj_v2 == get_vec<Type, 4>(kExpected));
+        CHECK(v1_proj_v2 == get_approx_vec<Type, 4>(kExpected));
     }
 }
 
 TEST_CASE_TEMPLATE("Project onto unit", Type, VALID_TYPES) {
-    // Shared input data:
-    constexpr TestArray kInput1{1.0L, -2.1L, 3.5L, 4.0L};
-    constexpr TestArray kInput2{-1.0L, 0.0L, 0.0L, 0.0L};
+    constexpr TestArray kInput1{1.0, -2.1, 3.5, 4.0};
+    constexpr TestArray kInput2{-1.0, 0.0, 0.0, 0.0};
 
     SUBCASE("2D") {
-        constexpr TestArray kExpected{1.0L, 0.0L};
+        constexpr TestArray kExpected{1.0, 0.0};
         constexpr auto v1 = get_vec<Type, 2>(kInput1);
         constexpr auto v2 = get_vec<Type, 2>(kInput2);
         constexpr Vec<Type, 2> v1_proj_unit_v2 = project_onto_unit(v1, v2);
-        CHECK(v1_proj_unit_v2 == get_vec<Type, 2>(kExpected));
+        CHECK(v1_proj_unit_v2 == get_approx_vec<Type, 2>(kExpected));
     }
 
     SUBCASE("3D") {
-        constexpr TestArray kExpected{1.0L, 0.0L, 0.0L};
+        constexpr TestArray kExpected{1.0, 0.0, 0.0};
         constexpr auto v1 = get_vec<Type, 3>(kInput1);
         constexpr auto v2 = get_vec<Type, 3>(kInput2);
         constexpr Vec<Type, 3> v1_proj_unit_v2 = project_onto_unit(v1, v2);
-        CHECK(v1_proj_unit_v2 == get_vec<Type, 3>(kExpected));
+        CHECK(v1_proj_unit_v2 == get_approx_vec<Type, 3>(kExpected));
     }
 
     SUBCASE("4D") {
-        constexpr TestArray kExpected{1.0L, 0.0L, 0.0L, 0.0L};
+        constexpr TestArray kExpected{1.0, 0.0, 0.0, 0.0};
         constexpr auto v1 = get_vec<Type, 4>(kInput1);
         constexpr auto v2 = get_vec<Type, 4>(kInput2);
         constexpr Vec<Type, 4> v1_proj_unit_v2 = project_onto_unit(v1, v2);
-        CHECK(v1_proj_unit_v2 == get_vec<Type, 4>(kExpected));
+        CHECK(v1_proj_unit_v2 == get_approx_vec<Type, 4>(kExpected));
     }
 }
 
 TEST_CASE_TEMPLATE("Reject from", Type, VALID_TYPES) {
-    // Shared input data:
-    constexpr TestArray kInput1{1.0L, -2.1L, 3.5L, 4.0L};
-    constexpr TestArray kInput2{-5.0L, 6.0L, 7.2L, 8.2L};
+    constexpr TestArray kInput1{1.0, -2.1, 3.5, 4.0};
+    constexpr TestArray kInput2{-5.0, 6.0, 7.2, 8.2};
 
     SUBCASE("2D") {
         // Note: higher resolution provided for operator== check below
-        constexpr TestArray kExpected{-0.442622950819672130980467L,
-                                      -0.368852459016393442628283L};
+        constexpr TestArray kExpected{-0.4426229508, -0.3688524590};
         constexpr auto v1 = get_vec<Type, 2>(kInput1);
         constexpr auto v2 = get_vec<Type, 2>(kInput2);
         constexpr Vec<Type, 2> v1_rej_v2 = reject_from(v1, v2);
-        CHECK(v1_rej_v2 == get_vec<Type, 2>(kExpected));
+        CHECK(v1_rej_v2 == get_approx_vec<Type, 2>(kExpected));
     }
 
     SUBCASE("3D") {
-        constexpr TestArray kExpected{1.336760014179369018111863L,
-                                      -2.504112017015242821690868L,
-                                      3.015065579581708613953611L};
+        constexpr TestArray kExpected{1.3367600141, -2.5041120170, 3.0150655795};
         constexpr auto v1 = get_vec<Type, 3>(kInput1);
         constexpr auto v2 = get_vec<Type, 3>(kInput2);
         constexpr Vec<Type, 3> v1_rej_v2 = reject_from(v1, v2);
-        CHECK(v1_rej_v2 == get_vec<Type, 3>(kExpected));
+        CHECK(v1_rej_v2 == get_approx_vec<Type, 3>(kExpected));
     }
 
     SUBCASE("4D") {
-        constexpr TestArray kExpected{2.121723678365171035205619L,
-                                      -3.446068414038205242246743L,
-                                      1.884717903154153709286561L,
-                                      2.160373167481119502375542L};
+        constexpr TestArray kExpected{2.1217236783, -3.4460684140, 1.8847179031, 2.1603731674};
         constexpr auto v1 = get_vec<Type, 4>(kInput1);
         constexpr auto v2 = get_vec<Type, 4>(kInput2);
         constexpr Vec<Type, 4> v1_rej_v2 = reject_from(v1, v2);
-        CHECK(v1_rej_v2 == get_vec<Type, 4>(kExpected));
+        CHECK(v1_rej_v2 == get_approx_vec<Type, 4>(kExpected));
     }
 }
 
 TEST_CASE_TEMPLATE("Reject from unit", Type, VALID_TYPES) {
-    // Shared input data:
-    constexpr TestArray kInput1{1.0L, -2.1L, 3.5L, 4.0L};
-    constexpr TestArray kInput2{0.0L, 1.0L, 0.0L, 0.0L};
+    constexpr TestArray kInput1{1.0, -2.1, 3.5, 4.0};
+    constexpr TestArray kInput2{0.0, 1.0, 0.0, 0.0};
 
     SUBCASE("2D") {
-        constexpr TestArray kExpected{1.0L, 0.0L};
+        constexpr TestArray kExpected{1.0, 0.0};
         constexpr auto v1 = get_vec<Type, 2>(kInput1);
         constexpr auto v2 = get_vec<Type, 2>(kInput2);
         constexpr Vec<Type, 2> v1_rej_unit_v2 = reject_from_unit(v1, v2);
-        CHECK(v1_rej_unit_v2 == get_vec<Type, 2>(kExpected));
+        CHECK(v1_rej_unit_v2 == get_approx_vec<Type, 2>(kExpected));
     }
 
     SUBCASE("3D") {
-        constexpr TestArray kExpected{1.0L, 0.0L, 3.5L};
+        constexpr TestArray kExpected{1.0, 0.0, 3.5};
         constexpr auto v1 = get_vec<Type, 3>(kInput1);
         constexpr auto v2 = get_vec<Type, 3>(kInput2);
         constexpr Vec<Type, 3> v1_rej_unit_v2 = reject_from_unit(v1, v2);
-        CHECK(v1_rej_unit_v2 == get_vec<Type, 3>(kExpected));
+        CHECK(v1_rej_unit_v2 == get_approx_vec<Type, 3>(kExpected));
     }
 
     SUBCASE("4D") {
-        constexpr TestArray kExpected{1.0L, 0.0L, 3.5L, 4.0L};
+        constexpr TestArray kExpected{1.0, 0.0, 3.5, 4.0};
         constexpr auto v1 = get_vec<Type, 4>(kInput1);
         constexpr auto v2 = get_vec<Type, 4>(kInput2);
         constexpr Vec<Type, 4> v1_rej_unit_v2 = reject_from_unit(v1, v2);
-        CHECK(v1_rej_unit_v2 == get_vec<Type, 4>(kExpected));
+        CHECK(v1_rej_unit_v2 == get_approx_vec<Type, 4>(kExpected));
     }
 }

--- a/tests/test_vec_operators.cpp
+++ b/tests/test_vec_operators.cpp
@@ -12,9 +12,8 @@
 #include "vec.hpp"
 
 TEST_CASE_TEMPLATE("Access elements by []", Type, VALID_TYPES) {
-    // Shared input data:
-    constexpr TestArray kInput{1.0L, 2.0L, 3.0L, 4.0L};
-    constexpr Type kOffset{static_cast<Type>(7)}; // arbitrary
+    constexpr TestArray kInput{1.0, 2.0, 3.0, 4.0};
+    constexpr Type kOffset = 7;
 
     SUBCASE("2D") {
         auto v = get_vec<Type, 2>(kInput);
@@ -48,138 +47,132 @@ TEST_CASE_TEMPLATE("Access elements by []", Type, VALID_TYPES) {
 }
 
 TEST_CASE_TEMPLATE("Vector += vector", Type, VALID_TYPES) {
-    // Shared input and expected output data:
-    constexpr TestArray kInput1{1.2L, 2.0L, 3.5L, -14.0L};
-    constexpr TestArray kInput2{-5.0L, 6.0L, 7.0L, 8.0L};
-    constexpr TestArray kExpected{-3.8L, 8.0L, 10.5L, -6.0L};
+    constexpr TestArray kInput1{1.2, 2.0, 3.5, -14.0};
+    constexpr TestArray kInput2{-5.0, 6.0, 7.0, 8.0};
+    constexpr TestArray kExpected{-3.8, 8.0, 10.5, -6.0};
 
     SUBCASE("2D") {
         auto v1 = get_vec<Type, 2>(kInput1);
         constexpr auto v2 = get_vec<Type, 2>(kInput2);
         v1 += v2;
-        CHECK(v1 == get_vec<Type, 2>(kExpected));
+        CHECK(v1 == get_approx_vec<Type, 2>(kExpected));
     }
 
     SUBCASE("3D") {
         auto v1 = get_vec<Type, 3>(kInput1);
         constexpr auto v2 = get_vec<Type, 3>(kInput2);
         v1 += v2;
-        CHECK(v1 == get_vec<Type, 3>(kExpected));
+        CHECK(v1 == get_approx_vec<Type, 3>(kExpected));
     }
 
     SUBCASE("4D") {
         auto v1 = get_vec<Type, 4>(kInput1);
         constexpr auto v2 = get_vec<Type, 4>(kInput2);
         v1 += v2;
-        CHECK(v1 == get_vec<Type, 4>(kExpected));
+        CHECK(v1 == get_approx_vec<Type, 4>(kExpected));
     }
 }
 
 TEST_CASE_TEMPLATE("Vector -= vector", Type, VALID_TYPES) {
-    // Shared input and expected output data:
-    constexpr TestArray kInput1{1.2L, 2.0L, -15.0L, 20.7L};
-    constexpr TestArray kInput2{5.0L, 6.0L, 7.0L, 8.0L};
-    constexpr TestArray kExpected{-3.8L, -4.0L, -22.0L, 12.7L};
+    constexpr TestArray kInput1{1.2, 2.0, -15.0, 20.7};
+    constexpr TestArray kInput2{5.0, 6.0, 7.0, 8.0};
+    constexpr TestArray kExpected{-3.8, -4.0, -22.0, 12.7};
 
     SUBCASE("2D") {
         auto v1 = get_vec<Type, 2>(kInput1);
         constexpr auto v2 = get_vec<Type, 2>(kInput2);
         v1 -= v2;
-        CHECK(v1 == get_vec<Type, 2>(kExpected));
+        CHECK(v1 == get_approx_vec<Type, 2>(kExpected));
     }
 
     SUBCASE("3D") {
         auto v1 = get_vec<Type, 3>(kInput1);
         constexpr auto v2 = get_vec<Type, 3>(kInput2);
         v1 -= v2;
-        CHECK(v1 == get_vec<Type, 3>(kExpected));
+        CHECK(v1 == get_approx_vec<Type, 3>(kExpected));
     }
 
     SUBCASE("4D") {
         auto v1 = get_vec<Type, 4>(kInput1);
         constexpr auto v2 = get_vec<Type, 4>(kInput2);
         v1 -= v2;
-        CHECK(v1 == get_vec<Type, 4>(kExpected));
+        CHECK(v1 == get_approx_vec<Type, 4>(kExpected));
     }
 }
 
 TEST_CASE_TEMPLATE("Vector *= scalar", Type, VALID_TYPES) {
-    // Shared input and expected output data:
-    constexpr TestArray kInput{0.0L, 2.6L, 3.0L, -4.0L};
-    constexpr Type kScalar{static_cast<Type>(2.4L)};
-    constexpr TestArray kExpected{0.0L, 6.24L, 7.2L, -9.6L};
+    constexpr TestArray kInput{0.0, 2.6, 3.0, -4.0};
+    constexpr Type kScalar = 2.4;
+    constexpr TestArray kExpected{0.0, 6.24, 7.2, -9.6};
 
     SUBCASE("2D") {
         auto v = get_vec<Type, 2>(kInput);
         v *= kScalar;
-        CHECK(v == get_vec<Type, 2>(kExpected));
+        CHECK(v == get_approx_vec<Type, 2>(kExpected));
     }
 
     SUBCASE("3D") {
         auto v = get_vec<Type, 3>(kInput);
         v *= kScalar;
-        CHECK(v == get_vec<Type, 3>(kExpected));
+        CHECK(v == get_approx_vec<Type, 3>(kExpected));
     }
 
     SUBCASE("4D") {
         auto v = get_vec<Type, 4>(kInput);
         v *= kScalar;
-        CHECK(v == get_vec<Type, 4>(kExpected));
+        CHECK(v == get_approx_vec<Type, 4>(kExpected));
     }
 }
 
 TEST_CASE_TEMPLATE("Vector /= scalar", Type, VALID_TYPES) {
-    // Shared input and expected output data:
-    constexpr TestArray kInput{0.0L, 2.8L, 28.0L, -5.6L};
-    constexpr Type kScalar{static_cast<Type>(1.4L)};
-    constexpr TestArray kExpected{0.0L, 2.0L, 20.0L, -4.0L};
+    constexpr TestArray kInput{0.0, 2.8, 28.0, -5.6};
+    constexpr Type kScalar = 1.4;
+    constexpr TestArray kExpected{0.0, 2.0, 20.0, -4.0};
 
     SUBCASE("2D") {
         auto v = get_vec<Type, 2>(kInput);
         v /= kScalar;
-        CHECK(v == get_vec<Type, 2>(kExpected));
+        CHECK(v == get_approx_vec<Type, 2>(kExpected));
     }
 
     SUBCASE("3D") {
         auto v = get_vec<Type, 3>(kInput);
         v /= kScalar;
-        CHECK(v == get_vec<Type, 3>(kExpected));
+        CHECK(v == get_approx_vec<Type, 3>(kExpected));
     }
 
     SUBCASE("4D") {
         auto v = get_vec<Type, 4>(kInput);
         v /= kScalar;
-        CHECK(v == get_vec<Type, 4>(kExpected));
+        CHECK(v == get_approx_vec<Type, 4>(kExpected));
     }
 }
 
 TEST_CASE_TEMPLATE("Negate (-vector)", Type, VALID_TYPES) {
-    // Shared input and expected output data:
-    constexpr TestArray kInput{1.0L, -22.1L, 0.0L, 3.9L};
-    constexpr TestArray kExpected{-1.0L, 22.1L, 0.0L, -3.9L};
+    constexpr TestArray kInput{1.0, -22.1, 0.0, 3.9};
+    constexpr TestArray kExpected{-1.0, 22.1, 0.0, -3.9};
 
     SUBCASE("2D") {
         constexpr auto v = get_vec<Type, 2>(kInput);
         constexpr auto v_neg = -v;
-        CHECK(v_neg == get_vec<Type, 2>(kExpected));
+        CHECK(v_neg == get_approx_vec<Type, 2>(kExpected));
     }
 
     SUBCASE("3D") {
         constexpr auto v = get_vec<Type, 3>(kInput);
         constexpr auto v_neg = -v;
-        CHECK(v_neg == get_vec<Type, 3>(kExpected));
+        CHECK(v_neg == get_approx_vec<Type, 3>(kExpected));
     }
 
     SUBCASE("4D") {
         constexpr auto v = get_vec<Type, 4>(kInput);
         constexpr auto v_neg = -v;
-        CHECK(v_neg == get_vec<Type, 4>(kExpected));
+        CHECK(v_neg == get_approx_vec<Type, 4>(kExpected));
     }
 }
 
 TEST_CASE_TEMPLATE("Vector ==/!= vector", Type, VALID_TYPES) {
-    // Shared input and expected output data:
-    constexpr TestArray kInput{1.0L, -22.01L, 0.0L, 3.999L};
+    constexpr TestArray kInput{1.0, -22.01, 0.0, 3.999};
 
     SUBCASE("2D") {
         // Check equality case
@@ -231,118 +224,115 @@ TEST_CASE_TEMPLATE("Vector ==/!= vector", Type, VALID_TYPES) {
 }
 
 TEST_CASE_TEMPLATE("Vector - vector", Type, VALID_TYPES) {
-    // Shared input and expected output data:
-    constexpr TestArray kInput1{1.2L, 2.0L, -15.0L, 20.7L};
-    constexpr TestArray kInput2{5.0L, 6.0L, 7.0L, 8.0L};
-    constexpr TestArray kExpected{-3.8L, -4.0L, -22.0L, 12.7L};
+    constexpr TestArray kInput1{1.2, 2.0, -15.0, 20.7};
+    constexpr TestArray kInput2{5.0, 6.0, 7.0, 8.0};
+    constexpr TestArray kExpected{-3.8, -4.0, -22.0, 12.7};
 
     SUBCASE("2D") {
         constexpr auto v1 = get_vec<Type, 2>(kInput1);
         constexpr auto v2 = get_vec<Type, 2>(kInput2);
         constexpr Vec<Type, 2> v_diff = v1 - v2;
-        CHECK(v_diff == get_vec<Type, 2>(kExpected));
+        CHECK(v_diff == get_approx_vec<Type, 2>(kExpected));
     }
 
     SUBCASE("3D") {
         constexpr auto v1 = get_vec<Type, 3>(kInput1);
         constexpr auto v2 = get_vec<Type, 3>(kInput2);
         constexpr Vec<Type, 3> v_diff = v1 - v2;
-        CHECK(v_diff == get_vec<Type, 3>(kExpected));
+        CHECK(v_diff == get_approx_vec<Type, 3>(kExpected));
     }
 
     SUBCASE("4D") {
         constexpr auto v1 = get_vec<Type, 4>(kInput1);
         constexpr auto v2 = get_vec<Type, 4>(kInput2);
         constexpr Vec<Type, 4> v_diff = v1 - v2;
-        CHECK(v_diff == get_vec<Type, 4>(kExpected));
+        CHECK(v_diff == get_approx_vec<Type, 4>(kExpected));
     }
 }
 
 TEST_CASE_TEMPLATE("Vector + vector", Type, VALID_TYPES) {
-    // Shared input and expected output data:
-    constexpr TestArray kInput1{1.2L, 0.0L, 3.0L, 4.1L};
-    constexpr TestArray kInput2{5.0L, 123.1L, -7.2L, 8.1L};
-    constexpr TestArray kExpected{6.2L, 123.1L, -4.2L, 12.2L};
+    constexpr TestArray kInput1{1.2, 0.0, 3.0, 4.1};
+    constexpr TestArray kInput2{5.0, 123.1, -7.2, 8.1};
+    constexpr TestArray kExpected{6.2, 123.1, -4.2, 12.2};
 
     SUBCASE("2D") {
         constexpr auto v1 = get_vec<Type, 2>(kInput1);
         constexpr auto v2 = get_vec<Type, 2>(kInput2);
         constexpr auto v_sum = v1 + v2;
-        CHECK(v_sum == get_vec<Type, 2>(kExpected));
+        CHECK(v_sum == get_approx_vec<Type, 2>(kExpected));
     }
 
     SUBCASE("3D") {
         constexpr auto v1 = get_vec<Type, 3>(kInput1);
         constexpr auto v2 = get_vec<Type, 3>(kInput2);
         constexpr auto v_sum = v1 + v2;
-        CHECK(v_sum == get_vec<Type, 3>(kExpected));
+        CHECK(v_sum == get_approx_vec<Type, 3>(kExpected));
     }
 
     SUBCASE("4D") {
         constexpr auto v1 = get_vec<Type, 4>(kInput1);
         constexpr auto v2 = get_vec<Type, 4>(kInput2);
         constexpr auto v_sum = v1 + v2;
-        CHECK(v_sum == get_vec<Type, 4>(kExpected));
+        CHECK(v_sum == get_approx_vec<Type, 4>(kExpected));
     }
 }
 
 TEST_CASE_TEMPLATE("Vector * scalar", Type, VALID_TYPES) {
-    // Shared input and expected output data:
-    constexpr TestArray kInput{0.0L, 2.6L, 3.0L, -4.0L};
-    constexpr Type kScalar{static_cast<Type>(2.4L)};
-    constexpr TestArray kExpected{0.0L, 6.24L, 7.2L, -9.6L};
+    constexpr TestArray kInput{0.0, 2.6, 3.0, -4.0};
+    constexpr Type kScalar = 2.4;
+    constexpr TestArray kExpected{0.0, 6.24, 7.2, -9.6};
 
     SUBCASE("2D") {
         constexpr auto v = get_vec<Type, 2>(kInput);
         constexpr Vec<Type, 2> v_product = v * kScalar;
         constexpr Vec<Type, 2> v_product_reverse = kScalar * v;
-        CHECK(v_product == get_vec<Type, 2>(kExpected));
-        CHECK(v_product_reverse == get_vec<Type, 2>(kExpected));
+        CHECK(v_product == get_approx_vec<Type, 2>(kExpected));
+        CHECK(v_product_reverse == get_approx_vec<Type, 2>(kExpected));
     }
 
     SUBCASE("3D") {
         constexpr auto v = get_vec<Type, 3>(kInput);
         constexpr Vec<Type, 3> v_product = v * kScalar;
         constexpr Vec<Type, 3> v_product_reverse = kScalar * v;
-        CHECK(v_product == get_vec<Type, 3>(kExpected));
+        CHECK(v_product == get_approx_vec<Type, 3>(kExpected));
+        CHECK(v_product_reverse == get_approx_vec<Type, 3>(kExpected));
     }
 
     SUBCASE("4D") {
         constexpr auto v = get_vec<Type, 4>(kInput);
         constexpr Vec<Type, 4> v_product = v * kScalar;
         constexpr Vec<Type, 4> v_product_reverse = kScalar * v;
-        CHECK(v_product == get_vec<Type, 4>(kExpected));
+        CHECK(v_product == get_approx_vec<Type, 4>(kExpected));
+        CHECK(v_product_reverse == get_approx_vec<Type, 4>(kExpected));
     }
 }
 
 TEST_CASE_TEMPLATE("Vector / scalar", Type, VALID_TYPES) {
-    // Shared input and expected output data:
-    constexpr TestArray kInput{0.0L, 2.8L, 28.0L, -5.6L};
-    constexpr Type kScalar{static_cast<Type>(1.4L)};
-    constexpr TestArray kExpected{0.0L, 2.0L, 20.0L, -4.0L};
+    constexpr TestArray kInput{0.0, 2.8, 28.0, -5.6};
+    constexpr Type kScalar = 1.4;
+    constexpr TestArray kExpected{0.0, 2.0, 20.0, -4.0};
 
     SUBCASE("2D") {
         constexpr auto v = get_vec<Type, 2>(kInput);
         constexpr Vec<Type, 2> v_quotient = v / kScalar;
-        CHECK(v_quotient == get_vec<Type, 2>(kExpected));
+        CHECK(v_quotient == get_approx_vec<Type, 2>(kExpected));
     }
 
     SUBCASE("3D") {
         constexpr auto v = get_vec<Type, 3>(kInput);
         constexpr Vec<Type, 3> v_quotient = v / kScalar;
-        CHECK(v_quotient == get_vec<Type, 3>(kExpected));
+        CHECK(v_quotient == get_approx_vec<Type, 3>(kExpected));
     }
 
     SUBCASE("4D") {
         constexpr auto v = get_vec<Type, 4>(kInput);
         constexpr Vec<Type, 4> v_quotient = v / kScalar;
-        CHECK(v_quotient == get_vec<Type, 4>(kExpected));
+        CHECK(v_quotient == get_approx_vec<Type, 4>(kExpected));
     }
 }
 
 TEST_CASE_TEMPLATE("Ostream operator", Type, VALID_TYPES) {
-    // Shared input data:
-    constexpr TestArray kInput{1.0L, 2.001L, -3.999L, 4.5L};
+    constexpr TestArray kInput{1.0, 2.001, -3.999, 4.5};
 
     // Configure output resolution
     std::stringstream out;


### PR DESCRIPTION
Remove L suffix from TestArray/TestGrid literals now that they're just
doubles. Remove unnecessary static casts. Use the approx accessor where
appropriate for comparisons.