### PR TITLE
Add affine transform class template and unit tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,6 +67,12 @@ target_link_libraries(test_mat_friends LINK_PUBLIC vec doctest test_utils)
 target_compile_options(test_mat_friends PRIVATE -O0)
 add_test(test_mat_friends test_mat_friends)
 
+# Transform test executables
+add_executable(test_transform tests/test_transform.cpp)
+target_link_libraries(test_transform LINK_PUBLIC vec doctest test_utils)
+target_compile_options(test_transform PRIVATE -O0)
+add_test(test_transform test_transform)
+
 ########################################
 # EXAMPLES
 ########################################

--- a/include/mat.hpp
+++ b/include/mat.hpp
@@ -17,18 +17,18 @@ namespace vec {
 template<typename Type, size_t M>
 class Mat;
 
-// Aliases for supported lengths and types
-using Mat22f = Mat<float, 2>;
-using Mat33f = Mat<float, 3>;
-using Mat44f = Mat<float, 4>;
+// Aliases for supported types and sizes
+using Mat2f = Mat<float, 2>;
+using Mat3f = Mat<float, 3>;
+using Mat4f = Mat<float, 4>;
 
-using Mat22d = Mat<double, 2>;
-using Mat33d = Mat<double, 3>;
-using Mat44d = Mat<double, 4>;
+using Mat2d = Mat<double, 2>;
+using Mat3d = Mat<double, 3>;
+using Mat4d = Mat<double, 4>;
 
-using Mat22ld = Mat<long double, 2>;
-using Mat33ld = Mat<long double, 3>;
-using Mat44ld = Mat<long double, 4>;
+using Mat2ld = Mat<long double, 2>;
+using Mat3ld = Mat<long double, 3>;
+using Mat4ld = Mat<long double, 4>;
 
 // Matrix class template
 template<typename Type, size_t M>
@@ -81,13 +81,17 @@ public:
                     {e20, e21, e22, e23},
                     {e30, e31, e32, e33}} {}
 
-    // Construct matrix from another matrix of equal or higher dimension
+    // Construct matrix from another matrix
     template <size_t N>
     requires (N >= M)
     constexpr explicit Mat(const MatT& other) {
         std::copy(other.cbegin(),
-                  other.cbegin() + M,
+                  other.cbegin() + std::min(M, N),
                   begin());
+        // If source matrix is smaller, fill remaining rows with zero-vectors
+        if constexpr (N < M) {
+            std::fill(begin() + N, end(), VecT(0));
+        }
     }
 
     // Construct MxM matrix filled with argument value
@@ -225,7 +229,6 @@ public:
         const MatT &m = *this;
 
         using Vec3T = Vec<Type, 3>;
-        // TODO: Get 3D slice from 4D vectors instead of copying?
         const auto a = Vec3T(m[0]); // 3D <- 4D
         const auto b = Vec3T(m[1]); // 3D <- 4D
         const auto c = Vec3T(m[2]); // 3D <- 4D
@@ -472,7 +475,7 @@ public:
                           row_compare);         // comparison
     }
 
-private:
+protected:
     // Matrix rows
     std::array<VecT, M> rows_;
 };

--- a/include/transform.hpp
+++ b/include/transform.hpp
@@ -1,0 +1,100 @@
+// Affine transformation class template (and related helpers)
+
+#pragma once
+
+#include "mat.hpp"
+
+namespace vec {
+
+// Forward declaration
+template<typename Type, size_t M>
+class AffineTransform;
+
+// Aliases for supported types and sizes
+using Transform2f = AffineTransform<float, 2>;
+using Transform3f = AffineTransform<float, 3>;
+
+using Transform2d = AffineTransform<double, 2>;
+using Transform3d = AffineTransform<double, 3>;
+
+using Transform2ld = AffineTransform<long double, 2>;
+using Transform3ld = AffineTransform<long double, 3>;
+
+// Affine transform class template
+// Extends matrix class template with size M+1 to enable homogeneous coordinate representation
+template<typename Type, size_t M>
+class AffineTransform final : public Mat<Type, M+1> {
+    // Template parameter assertions
+    static_assert((M >= 2) && (M <= 3), "Transform must be 2D or 3D (3x3 or 4x4 matrix)");
+    static_assert(std::is_floating_point_v<Type>, "Type must be floating-point");
+
+    // Type aliases for convenience
+    using BaseMatT = Mat<Type, M+1>;
+    using MatT = Mat<Type, M>;
+    using VecT = Vec<Type, M>;
+
+    // Template-param dependent parent members
+    using BaseMatT::rows_;
+    using BaseMatT::begin;
+
+public:
+    // Construct default affine transform (identity transform, zero translation)
+    constexpr AffineTransform() : AffineTransform(MatT::identity(), VecT(0)) {}
+
+    // Construct affine transform from MxM transform matrix and M-dimensional translation vector
+    constexpr AffineTransform(MatT m_linear_transform, VecT v_translation) {
+        set_linear_transform(m_linear_transform);
+        set_translation(v_translation);
+        rows_[M][M] = 1;
+    }
+
+    // Construct affine transform from MxM transform matrix (zero translation)
+    constexpr explicit AffineTransform(MatT m_linear_transform)
+            : AffineTransform(m_linear_transform, VecT(0)) {}
+
+    // Construct affine transform from M-dimensional translation vector (identity transform)
+    constexpr explicit AffineTransform(VecT v_translation)
+            : AffineTransform(MatT::identity(), v_translation) {}
+
+    // Get the MxM matrix representing the linear transform
+    constexpr MatT get_linear_transform() const {
+        MatT out;
+        std::transform(rows_.cbegin(), rows_.cbegin() + M,
+                       out.begin(),
+                       slice_vec);
+        return out;
+    }
+
+    // Set the MxM matrix representing the linear transform
+    constexpr void set_linear_transform(const MatT& m_linear_transform) {
+        std::transform(m_linear_transform.cbegin(), m_linear_transform.cend(),
+                       begin(),
+                       pad_vec);
+    }
+
+    // Get the M-dimensional vector representing the translation
+    constexpr VecT get_translation() const {
+        return VecT(rows_[M]);
+    }
+
+    // Set the M-dimensional vector representing the translation
+    constexpr void set_translation(const VecT& v_translation) {
+        // Note: copy elements directly to prevent overwriting bottom-rightmost element
+        std::copy(v_translation.cbegin(), v_translation.cend(), rows_[M].begin());
+    }
+private:
+    // Helper to pad vector with trailing 0
+    static constexpr auto pad_vec = [](const Vec<Type, M>& blah) {
+        return Vec<Type, M+1>(blah);
+    };
+
+    // Helper to slice vector (drop final element)
+    static constexpr auto slice_vec = [](const Vec<Type, M+1>& blah) {
+        return Vec<Type, M>(blah);
+    };
+};
+
+// TODO: Helpers for rotation, reflection, scale, skew
+
+} // namespace vec
+

--- a/include/vec.hpp
+++ b/include/vec.hpp
@@ -22,7 +22,7 @@ namespace vec {
 template<typename Type, size_t M>
 class Vec;
 
-// Aliases for supported lengths and types
+// Aliases for supported types and sizes
 using Vec2f = Vec<float, 2>;
 using Vec3f = Vec<float, 3>;
 using Vec4f = Vec<float, 4>;
@@ -60,25 +60,28 @@ class Vec {
     using VecT = Vec<Type, M>;
 
 public:
-    // Construct vector with zero-init elements
+    // Construct M-dimensional vector with zero-init elements
     // TODO: consider uninitialized constructor
     constexpr Vec() : elems_{} {}
 
-    // Construct vector from parameter pack of elements (full specification required)
+    // Construct M-dimensional vector from parameter pack of M elements
     template<typename ...Args>
     requires IsFullySpecified<M, Args...>
     constexpr Vec(Args... args) : elems_{args...} {}
 
-    // Construct vector from another vector of equal or higher dimension
+    // Construct M-dimensional vector from another vector
     template <size_t N>
-    requires (N >= M)
     constexpr explicit Vec(const Vec<Type, N>& other) {
         std::copy(other.cbegin(),
-                  other.cbegin() + M,
+                  other.cbegin() + std::min(M, N),
                   begin());
+        // If source vector is smaller, fill remaining elements with zero
+        if constexpr (N < M) {
+            std::fill(begin() + N, end(), static_cast<Type>(0));
+        }
     }
 
-    // Construct vector and fill elements with argument value
+    // Construct M-dimensional vector and fill elements with argument value
     constexpr explicit Vec(Type fill_value) {
         elems_.fill(fill_value);
     }

--- a/tests/test_transform.cpp
+++ b/tests/test_transform.cpp
@@ -1,0 +1,217 @@
+// Unit tests for the Mat class implementation (friends)
+
+// Testing headers
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include "doctest.h"
+#include "test_utils.hpp"
+
+// UUT headers
+#include "transform.hpp"
+
+TEST_CASE_TEMPLATE("Construct default transform with no arguments", Type, VALID_TYPES) {
+    SUBCASE("2D") {
+        constexpr TestGrid kExpected{{
+                {1.0, 0.0, 0.0},
+                {0.0, 1.0, 0.0},
+                {0.0, 0.0, 1.0},
+        }};
+        constexpr AffineTransform<Type, 2> affine_transform;
+        CHECK(affine_transform == get_approx_mat<Type, 3>(kExpected));
+    }
+
+    SUBCASE("3D") {
+        constexpr TestGrid kExpected{{
+                {1.0, 0.0, 0.0, 0.0},
+                {0.0, 1.0, 0.0, 0.0},
+                {0.0, 0.0, 1.0, 0.0},
+                {0.0, 0.0, 0.0, 1.0},
+        }};
+        constexpr AffineTransform<Type, 3> affine_transform;
+        CHECK(affine_transform == get_approx_mat<Type, 4>(kExpected));
+    }
+}
+
+TEST_CASE_TEMPLATE("Construct transform with matrix and vector", Type, VALID_TYPES) {
+    constexpr TestGrid kInputTransform{{
+            {1.0, 2.0, -3.0},
+            {4.0, -5.0, 6.0},
+            {-7.0, 8.0, 9.0},
+    }};
+    constexpr TestArray kInputTranslation{1.0, 2.0, 3.0};
+
+    SUBCASE("2D") {
+        constexpr TestGrid kExpected{{
+                {1.0, 2.0, 0.0},
+                {4.0, -5.0, 0.0},
+                {1.0, 2.0, 1.0},
+        }};
+        constexpr auto transform_in = get_mat<Type, 2>(kInputTransform);
+        constexpr auto translation_in = get_vec<Type, 2>(kInputTranslation);
+        constexpr AffineTransform<Type, 2> affine_transform(transform_in, translation_in);
+        CHECK(affine_transform == get_approx_mat<Type, 3>(kExpected));
+    }
+
+    SUBCASE("3D") {
+        constexpr TestGrid kExpected{{
+                {1.0, 2.0, -3.0, 0.0},
+                {4.0, -5.0, 6.0, 0.0},
+                {-7.0, 8.0, 9.0, 0.0},
+                {1.0, 2.0, 3.0, 1.0},
+        }};
+        constexpr auto transform_in = get_mat<Type, 3>(kInputTransform);
+        constexpr auto translation_in = get_vec<Type, 3>(kInputTranslation);
+        constexpr AffineTransform<Type, 3> affine_transform(transform_in, translation_in);
+        CHECK(affine_transform == get_approx_mat<Type, 4>(kExpected));
+    }
+}
+
+TEST_CASE_TEMPLATE("Construct transform with matrix only", Type, VALID_TYPES) {
+    constexpr TestGrid kInputTransform{{
+            {1.0, 2.0, -3.0},
+            {4.0, -5.0, 6.0},
+            {-7.0, 8.0, 9.0},
+    }};
+    SUBCASE("2D") {
+        constexpr TestGrid kExpected{{
+                {1.0, 2.0, 0.0},
+                {4.0, -5.0, 0.0},
+                {0.0, 0.0, 1.0},
+        }};
+        constexpr auto transform_in = get_mat<Type, 2>(kInputTransform);
+        constexpr AffineTransform<Type, 2> affine_transform(transform_in);
+        CHECK(affine_transform == get_approx_mat<Type, 3>(kExpected));
+    }
+
+    SUBCASE("3D") {
+        constexpr TestGrid kExpected{{
+                {1.0, 2.0, -3.0, 0.0},
+                {4.0, -5.0, 6.0, 0.0},
+                {-7.0, 8.0, 9.0, 0.0},
+                {0.0, 0.0, 0.0, 1.0},
+        }};
+        constexpr auto transform_in = get_mat<Type, 3>(kInputTransform);
+        constexpr AffineTransform<Type, 3> affine_transform(transform_in);
+        CHECK(affine_transform == get_approx_mat<Type, 4>(kExpected));
+    }
+}
+TEST_CASE_TEMPLATE("Construct transform with vector only", Type, VALID_TYPES) {
+    constexpr TestArray kInputTranslation{1.0, 2.0, 3.0};
+    SUBCASE("2D") {
+        constexpr TestGrid kExpected{{
+                {1.0, 0.0, 0.0},
+                {0.0, 1.0, 0.0},
+                {1.0, 2.0, 1.0},
+        }};
+        constexpr auto translation_in = get_vec<Type, 2>(kInputTranslation);
+        constexpr AffineTransform<Type, 2> affine_transform(translation_in);
+        CHECK(affine_transform == get_approx_mat<Type, 3>(kExpected));
+    }
+
+    SUBCASE("3D") {
+        constexpr TestGrid kExpected{{
+                {1.0, 0.0, 0.0, 0.0},
+                {0.0, 1.0, 0.0, 0.0},
+                {0.0, 0.0, 1.0, 0.0},
+                {1.0, 2.0, 3.0, 1.0},
+        }};
+        constexpr auto translation_in = get_vec<Type, 3>(kInputTranslation);
+        constexpr AffineTransform<Type, 3> affine_transform(translation_in);
+        CHECK(affine_transform == get_approx_mat<Type, 4>(kExpected));
+    }
+}
+
+TEST_CASE_TEMPLATE("Test getting linear transform", Type, VALID_TYPES) {
+    constexpr TestGrid kInput{{
+            {1.0, 2.0, -3.0},
+            {4.0, -5.0, 6.0},
+            {-7.0, 8.0, 9.0},
+    }};
+    constexpr TestGrid kExpected{kInput};
+
+    SUBCASE("2D") {
+        constexpr AffineTransform<Type, 2> affine_transform(get_mat<Type, 2>(kInput));
+        constexpr Mat<Type, 2> linear_transform = affine_transform.get_linear_transform();
+        CHECK(linear_transform == get_mat<Type, 2>(kExpected));
+    }
+
+    SUBCASE("3D") {
+        constexpr AffineTransform<Type, 3> affine_transform(get_mat<Type, 3>(kInput));
+        constexpr Mat<Type, 3> linear_transform = affine_transform.get_linear_transform();
+        CHECK(linear_transform == get_mat<Type, 3>(kExpected));
+    }
+}
+
+TEST_CASE_TEMPLATE("Test setting linear transform", Type, VALID_TYPES) {
+    constexpr TestGrid kInput{{
+            {1.0, 2.0, -3.0},
+            {4.0, -5.0, 6.0},
+            {-7.0, 8.0, 9.0},
+    }};
+
+    SUBCASE("2D") {
+        constexpr TestGrid kExpected{{
+                {1.0, 2.0,  0.0},
+                {4.0, -5.0, 0.0},
+                {0.0, 0.0,  1.0},
+        }};
+        AffineTransform<Type, 2> affine_transform;
+        affine_transform.set_linear_transform(get_mat<Type, 2>(kInput));
+        CHECK(affine_transform == get_mat<Type, 3>(kExpected));
+    }
+
+    SUBCASE("3D") {
+        constexpr TestGrid kExpected{{
+                {1.0, 2.0, -3.0, 0.0},
+                {4.0, -5.0, 6.0, 0.0},
+                {-7.0, 8.0, 9.0, 0.0},
+                {0.0, 0.0, 0.0, 1.0},
+        }};
+        AffineTransform<Type, 3> affine_transform;
+        affine_transform.set_linear_transform(get_mat<Type, 3>(kInput));
+        CHECK(affine_transform == get_mat<Type, 4>(kExpected));
+    }
+}
+
+TEST_CASE_TEMPLATE("Test getting translation", Type, VALID_TYPES) {
+    constexpr TestArray kInput{1.0, 2.0, 3.0};
+    constexpr TestArray kExpected{kInput};
+
+    SUBCASE("2D") {
+        constexpr AffineTransform<Type, 2> affine_transform(get_vec<Type, 2>(kInput));
+        constexpr Vec<Type, 2> translation = affine_transform.get_translation();
+        CHECK(translation == get_vec<Type, 2>(kExpected));
+    }
+
+    SUBCASE("3D") {
+        constexpr AffineTransform<Type, 3> affine_transform(get_vec<Type, 3>(kInput));
+        constexpr Vec<Type, 3> translation = affine_transform.get_translation();
+        CHECK(translation == get_vec<Type, 3>(kExpected));
+    }
+}
+
+TEST_CASE_TEMPLATE("Test setting translation", Type, VALID_TYPES) {
+    constexpr TestArray kInput{1.0, 2.0, 3.0};
+
+    SUBCASE("2D") {
+        constexpr TestGrid kExpected{{
+                {1.0, 0.0, 0.0},
+                {0.0, 1.0, 0.0},
+                {1.0, 2.0, 1.0},
+        }};
+        AffineTransform<Type, 2> affine_transform;
+        affine_transform.set_translation(get_vec<Type, 2>(kInput));
+        CHECK(affine_transform == get_mat<Type, 3>(kExpected));
+    }
+
+    SUBCASE("3D") {
+        constexpr TestGrid kExpected{{
+                {1.0, 0.0, 0.0, 0.0},
+                {0.0, 1.0, 0.0, 0.0},
+                {0.0, 0.0, 1.0, 0.0},
+                {1.0, 2.0, 3.0, 1.0},
+        }};
+        AffineTransform<Type, 3> affine_transform;
+        affine_transform.set_translation(get_vec<Type, 3>(kInput));
+        CHECK(affine_transform == get_mat<Type, 4>(kExpected));
+    }
+}

--- a/tests/test_utils/test_utils.hpp
+++ b/tests/test_utils/test_utils.hpp
@@ -8,10 +8,13 @@
 
 #include "vec.hpp"
 #include "mat.hpp"
+#include "transform.hpp"
 
 using std::size_t;
+
 using vec::Vec;
 using vec::Mat;
+using vec::AffineTransform;
 
 // Types to template test cases over
 #define VALID_TYPES  float, double, long double


### PR DESCRIPTION
Add a new header file with an AffineTransform class template. This class
extends the matrix class with a template size of M+1 to enable a
homogeneous coordinate representation. Provides convenience constructors
and accessors for the linear transformation matrix and translation
vector components of the transform.

Add unit tests for the new class template.

Resolves #16 