### PR TITLE
Add rotation matrix helpers, perform cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,15 +25,11 @@ Some of my personal goals for this project are:
   my job, so I want to learn about some of the newer features of C++14/17/20 via this project.
 * **Utilize the standard library where possible**. I was a C programmer long before I started 
   writing C++, and one area of C++ I've been slow to adopt is the standard library's numerous
-  containers and algorithms.
-* **Provide a fully `constexpr` implementation**. C++14 greatly expanded the usability of 
-  `constexpr`, and C++20 provides `constexpr` standard algorithms. Surprisingly, the last missing 
-  piece is basic math operations like `sqrt()`. I'm providing `constexpr` implementations of these 
-  operations, but they're only used at compile-time thanks to `std::is_constant_evaluated()`.
-* **Follow through**. Complete a fully-functional library, including good test coverage and
-  documentation.
-* **Use this library to build something else**. Details to be determined, but this should serve as 
-  a base for future work involving graphics, games, and/or robotics programming.
+  containers and algorithms. I make extra effort to use them here, purely for practice.
+* **Attempt to provide a fully `constexpr` implementation**. C++14 greatly expanded the
+  usability of `constexpr`, and C++20 provides `constexpr` standard algorithms. Surprisingly,
+  the last missing piece is basic math operations like `sqrt()`. I'm providing `constexpr`
+  implementations for some of these operations, though some are still missing.
 
 ### Requirements / Dependencies
 
@@ -50,7 +46,10 @@ git submodule update --init
 
 ### Examples
 See the included [target hit detection example](examples/target_hit_detection.cpp) for a
-demonstration of basic vector arithmetic. Additional examples will be added in the future.
+demonstration of basic vector arithmetic. Additional examples may be added in the future. I've also
+used this library in a [basic raytracer application](https://github.com/embeddr/raytracer-cpp).
 
-### API
-*TODO*
+### Known Limitations
+* Cannot generate `constexpr` rotation matrices due to lack of `constexpr`implementations of basic
+  trigonometric functions like `sin()` and `cos()`. May implement these (or pull in a third-party
+  implementation) in the future, as this isn't expected in standard C++ until C++23.

--- a/include/mat.hpp
+++ b/include/mat.hpp
@@ -60,26 +60,26 @@ public:
     // Construct matrix from individual elements (2x2 specialization)
     constexpr Mat(Type e00, Type e01,
                   Type e10, Type e11) requires Is2D<M>
-            : rows_{{e00, e01},
-                    {e10, e11}} {}
+            : rows_{VecT{e00, e01},
+                    VecT{e10, e11}} {}
 
     // Construct matrix from individual elements (3x3 specialization)
     constexpr Mat(Type e00, Type e01, Type e02,
                   Type e10, Type e11, Type e12,
                   Type e20, Type e21, Type e22) requires Is3D<M>
-            : rows_{{e00, e01, e02},
-                    {e10, e11, e12},
-                    {e20, e21, e22}} {}
+            : rows_{VecT{e00, e01, e02},
+                    VecT{e10, e11, e12},
+                    VecT{e20, e21, e22}} {}
 
     // Construct matrix from individual elements (4x4 specialization)
     constexpr Mat(Type e00, Type e01, Type e02, Type e03,
                   Type e10, Type e11, Type e12, Type e13,
                   Type e20, Type e21, Type e22, Type e23,
                   Type e30, Type e31, Type e32, Type e33) requires Is4D<M>
-            : rows_{{e00, e01, e02, e03},
-                    {e10, e11, e12, e13},
-                    {e20, e21, e22, e23},
-                    {e30, e31, e32, e33}} {}
+            : rows_{VecT{e00, e01, e02, e03},
+                    VecT{e10, e11, e12, e13},
+                    VecT{e20, e21, e22, e23},
+                    VecT{e30, e31, e32, e33}} {}
 
     // Construct matrix from another matrix
     template <size_t N>

--- a/include/transform.hpp
+++ b/include/transform.hpp
@@ -2,6 +2,8 @@
 
 #pragma once
 
+#include <cmath>
+
 #include "mat.hpp"
 
 namespace vec {
@@ -56,6 +58,47 @@ public:
     constexpr explicit AffineTransform(VecT v_translation)
             : AffineTransform(MatT::identity(), v_translation) {}
 
+    /**************************************************************************
+     * STATIC MEMBER FUNCTIONS
+     **************************************************************************/
+
+    // Construct matrix for counter-clockwise rotation around the x axis in radians
+    constexpr static MatT rotate_x(Type rad) requires Is3D<M> {
+        return {1.0F, 0.0F,           0.0F,
+                0.0F, std::cos(rad), -std::sin(rad),
+                0.0F, std::sin(rad),  std::cos(rad)};
+    }
+
+    // Construct matrix for counter-clockwise rotation around the y axis in radians
+    constexpr static MatT rotate_y(Type rad) requires Is3D<M> {
+        return {
+            { std::cos(rad), 0.0F, std::sin(rad)},
+            { 0.0F,          1.0F, 0.0F},
+            {-std::sin(rad), 0.0F, std::cos(rad)},
+        };
+    }
+
+    // Construct matrix for counter-clockwise rotation around the z axis in radians
+    constexpr static MatT rotate_z(Type rad) requires Is3D<M> {
+        return {
+            {std::cos(rad), -std::sin(rad), 0.0F},
+            {std::sin(rad),  std::cos(rad), 0.0F},
+            {0.0F,           0.0F,          1.0F},
+        };
+    }
+
+    // Construct matrix for counter-clockwise rotation of a 2D vector
+    constexpr static MatT rotate(Type rad) requires Is2D<M> {
+        return {
+                {std::cos(rad), -std::sin(rad)},
+                {std::sin(rad),  std::cos(rad)},
+        };
+    }
+
+    /**************************************************************************
+     * MEMBER FUNCTIONS
+     **************************************************************************/
+
     // Get the MxM matrix representing the linear transform
     constexpr MatT get_linear_transform() const {
         MatT out;
@@ -94,7 +137,7 @@ private:
     };
 };
 
-// TODO: Helpers for rotation, reflection, scale, skew
+// TODO: Helpers for reflection, scale, skew
 
 } // namespace vec
 

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -81,7 +81,7 @@ constexpr bool floating_point_eq(Type a, Type b,
     assert(epsilon >= std::numeric_limits<Type>::epsilon());
     assert(epsilon < static_cast<Type>(1));
 
-    // TODO: Add stackoverflow reference for this - it's useful reading
+    // See https://stackoverflow.com/a/32334103 for a great post on float comparisons
     if (a == b) { return true; }
     auto diff = abs(a - b); // utils::abs()
     auto norm = std::min(std::abs(a + b), std::numeric_limits<Type>::max());

--- a/include/vec.hpp
+++ b/include/vec.hpp
@@ -368,7 +368,6 @@ public:
     }
 
     // Get the dot product of M-dimensional vectors a and b
-    // TODO: make this a method instead; v1.dot(v2) is nice
     friend constexpr Type dot(const VecT& a, const VecT& b) {
         return std::inner_product(a.cbegin(), a.cend(),  // a input
                                   b.cbegin(),            // b input
@@ -376,7 +375,6 @@ public:
     }
 
     // Get the cross product of 3-dimensional vectors a and b
-    // TODO: make this a method instead; v1.cross(v2) is nice
     friend constexpr VecT cross(const VecT& a, const VecT& b) requires Is3D<M> {
         VecT out{
             static_cast<Type>(a.y() * b.z() - a.z() * b.y()),
@@ -414,25 +412,21 @@ public:
     }
 
     // Project M-dimensional vector a onto M-dimensional vector b
-    // TODO: make this a method instead; v1.project_onto(v2) is nice
     friend constexpr VecT project_onto(const VecT& a, const VecT& b) {
         return (b * dot(a, b) / b.euclidean2());
     }
 
     // Project M-dimensional vector a onto M-dimensional unit-length vector b
-    // TODO: make this a method instead; v1.project_onto_unit(v2) is nice
     friend constexpr VecT project_onto_unit(const VecT& a, const VecT& b) {
         return (b * dot(a, b));
     }
 
     // Reject M-dimensional vector a from M-dimensional vector b
-    // TODO: make this a method instead; v1.reject_from(v2) is nice
     friend constexpr VecT reject_from(const VecT& a, const VecT& b) {
         return a - project_onto(a, b);
     }
 
     // Reject M-dimensional vector a from M-dimensional unit-length vector b
-    // TODO: make this a method instead; v1.reject_from_unit(v2) is nice
     friend constexpr VecT reject_from_unit(const VecT& a, const VecT& b) {
         return a - project_onto_unit(a, b);
     }

--- a/tests/test_mat_basic.cpp
+++ b/tests/test_mat_basic.cpp
@@ -66,7 +66,42 @@ TEST_CASE_TEMPLATE("Construct matrix from column vectors", Type, VALID_TYPES) {
 }
 
 TEST_CASE_TEMPLATE("Construct matrix from individual elements", Type, VALID_TYPES) {
-    // TODO
+    constexpr TestGrid kTestValues{{
+            {1.0, 2.0, 3.0, 4.0},
+            {5.0, 6.0, 7.0, 8.0},
+            {-1.0, -2.0, -3.0, -4.0},
+            {-5.0, -6.0, -7.0, -8.0}
+    }};
+
+    SUBCASE("2D") {
+        constexpr auto v0 = get_vec<Type, 2>(kTestValues[0]);
+        constexpr auto v1 = get_vec<Type, 2>(kTestValues[1]);
+        constexpr Mat<Type, 2> m{v0[0], v0[1],
+                                 v1[0], v1[1]};
+        CHECK(m == get_mat<Type, 2>(kTestValues));
+    }
+
+    SUBCASE("3D") {
+        constexpr auto v0 = get_vec<Type, 3>(kTestValues[0]);
+        constexpr auto v1 = get_vec<Type, 3>(kTestValues[1]);
+        constexpr auto v2 = get_vec<Type, 3>(kTestValues[2]);
+        constexpr Mat<Type, 3> m{v0[0], v0[1], v0[2],
+                                 v1[0], v1[1], v1[2],
+                                 v2[0], v2[1], v2[2]};
+        CHECK(m == get_mat<Type, 3>(kTestValues));
+    }
+
+    SUBCASE("4D") {
+        constexpr auto v0 = get_vec<Type, 4>(kTestValues[0]);
+        constexpr auto v1 = get_vec<Type, 4>(kTestValues[1]);
+        constexpr auto v2 = get_vec<Type, 4>(kTestValues[2]);
+        constexpr auto v3 = get_vec<Type, 4>(kTestValues[3]);
+        constexpr Mat<Type, 4> m{v0[0], v0[1], v0[2], v0[3],
+                                 v1[0], v1[1], v1[2], v1[3],
+                                 v2[0], v2[1], v2[2], v2[3],
+                                 v3[0], v3[1], v3[2], v3[3]};
+        CHECK(m == get_mat<Type, 4>(kTestValues));
+    }
 }
 
 TEST_CASE_TEMPLATE("Construct matrix from other matrix", Type, VALID_TYPES) {

--- a/tests/test_transform.cpp
+++ b/tests/test_transform.cpp
@@ -120,6 +120,65 @@ TEST_CASE_TEMPLATE("Construct transform with vector only", Type, VALID_TYPES) {
     }
 }
 
+TEST_CASE_TEMPLATE("Construct x-axis rotation matrix", Type, VALID_TYPES) {
+    const Type kAngle = M_PI/2.0;
+    constexpr TestGrid kExpected{{
+            {1.0, 0.0, 0.0},
+            {0.0, 0.0, -1.0},
+            {0.0, 1.0, 0.0},
+    }};
+
+    // TODO: Add constexpr test once support for constexpr sin/cos is added
+    SUBCASE("3D") {
+        auto rotate_x = AffineTransform<Type, 3>::rotate_x(kAngle);
+        CHECK(rotate_x == get_approx_mat<Type, 3>(kExpected));
+    }
+}
+
+TEST_CASE_TEMPLATE("Construct y-axis rotation matrix", Type, VALID_TYPES) {
+    const Type kAngle = M_PI/2.0;
+    constexpr TestGrid kExpected{{
+            {0.0, 0.0, 1.0},
+            {0.0, 1.0, 0.0},
+            {-1.0, 0.0, 0.0},
+    }};
+
+    // TODO: Add constexpr test once support for constexpr sin/cos is added
+    SUBCASE("3D") {
+        auto rotate_y = AffineTransform<Type, 3>::rotate_y(kAngle);
+        CHECK(rotate_y == get_approx_mat<Type, 3>(kExpected));
+    }
+}
+
+TEST_CASE_TEMPLATE("Construct z-axis rotation matrix", Type, VALID_TYPES) {
+    const Type kAngle = M_PI/2.0;
+    constexpr TestGrid kExpected{{
+            {0.0, -1.0, 0.0},
+            {1.0, 0.0, 0.0},
+            {0.0, 0.0, 1.0},
+    }};
+
+    // TODO: Add constexpr test once support for constexpr sin/cos is added
+    SUBCASE("3D") {
+        auto rotate_z = AffineTransform<Type, 3>::rotate_z(kAngle);
+        CHECK(rotate_z == get_approx_mat<Type, 3>(kExpected));
+    }
+}
+
+TEST_CASE_TEMPLATE("Construct 2D rotation matrix", Type, VALID_TYPES) {
+    const Type kAngle = M_PI/2.0;
+    constexpr TestGrid kExpected{{
+            {0.0, -1.0},
+            {1.0, 0.0},
+    }};
+
+    // TODO: Add constexpr test once support for constexpr sin/cos is added
+    SUBCASE("2D") {
+        auto rotate_z = AffineTransform<Type, 2>::rotate(kAngle);
+        CHECK(rotate_z == get_approx_mat<Type, 2>(kExpected));
+    }
+}
+
 TEST_CASE_TEMPLATE("Test getting linear transform", Type, VALID_TYPES) {
     constexpr TestGrid kInput{{
             {1.0, 2.0, -3.0},

--- a/tests/test_utils/test_utils.hpp
+++ b/tests/test_utils/test_utils.hpp
@@ -44,15 +44,16 @@ public:
     }
 
     friend constexpr bool operator==(const Type& lhs, const Approx& rhs) {
-        return approx_eq(lhs, rhs.data_, rhs.epsilon_);
+        return approx_eq(lhs, rhs.data_, rhs.epsilon_, rhs.epsilon_);
     }
 
     friend constexpr bool operator==(const Approx& lhs, const Type& rhs) {
-        return approx_eq(lhs.data_, rhs, lhs.epsilon_);
+        return approx_eq(lhs.data_, rhs, lhs.epsilon_, lhs.epsilon_);
     }
 
     friend constexpr bool operator==(const Approx& lhs, const Approx& rhs) {
-        return approx_eq(lhs.data_, rhs.data_, std::min(lhs.epsilon_, rhs.epsilon_));
+        const Type epsilon = std::min(lhs.epsilon_, rhs.epsilon_);
+        return approx_eq(lhs.data_, rhs.data_, epsilon, epsilon);
     }
 
     friend std::ostream& operator<<(std::ostream& os, const Approx& rhs) {


### PR DESCRIPTION
Add helpers to create rotation matrices for rotation around the x, y,
or z axis. Clean up a few details and update unit tests.

#19 